### PR TITLE
Split the UpsertRepository interface

### DIFF
--- a/src/services/backends/kubernetes/repositories/schema_repository.rs
+++ b/src/services/backends/kubernetes/repositories/schema_repository.rs
@@ -21,7 +21,7 @@ use super::super::kubernetes_resource_manager::synchronized::SynchronizedKuberne
 use crate::services::backends::kubernetes::kubernetes_resource_manager::{
     KubernetesResourceManagerConfig, ResourceUpdateHandler,
 };
-use crate::services::base::upsert_repository::UpsertRepository;
+use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository, UpsertRepositoryWithDelete};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use cedar_policy::SchemaFragment;
@@ -121,10 +121,10 @@ impl ResourceUpdateHandler<SchemaConfigMap> for UpdateHandler {
 }
 
 #[async_trait]
-impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
-    type Error = anyhow::Error;
+impl ReadOnlyRepository<String, SchemaFragment> for KubernetesSchemaRepository {
+    type ReadError = anyhow::Error;
 
-    async fn get(&self, key: String) -> Result<SchemaFragment, Self::Error> {
+    async fn get(&self, key: String) -> Result<SchemaFragment, Self::ReadError> {
         let or = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
         let resource_object = self.resource_manger.get(or).map_err(|e| anyhow!(e))?;
         if resource_object.data.active.contains("false") {
@@ -133,6 +133,11 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
         let result: SchemaFragment = resource_object.data.clone().try_into()?;
         Ok(result)
     }
+}
+
+#[async_trait]
+impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
+    type Error = anyhow::Error;
 
     async fn upsert(&self, key: String, entity: SchemaFragment) -> Result<(), Self::Error> {
         let updated_configmap = SchemaConfigMap {
@@ -152,17 +157,6 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
             .map_err(|e| anyhow!("Failed to update ConfigMap: {}", e))
     }
 
-    async fn delete(&self, key: String) -> Result<(), Self::Error> {
-        let or = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
-        let mut resource_ref = self.resource_manger.get(or).map_err(|e| anyhow!(e))?;
-        if resource_ref.data.active.contains("false") {
-            return Ok(());
-        }
-        let resource_object = Arc::make_mut(&mut resource_ref);
-        resource_object.data.active = "false".to_string();
-        self.resource_manger.replace(&key, resource_object.clone()).await
-    }
-
     async fn exists(&self, key: String) -> Result<bool, Self::Error> {
         let or: ObjectRef<SchemaConfigMap> =
             ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
@@ -175,3 +169,21 @@ impl UpsertRepository<String, SchemaFragment> for KubernetesSchemaRepository {
         })
     }
 }
+
+#[async_trait]
+impl CanDelete<String, SchemaFragment> for KubernetesSchemaRepository {
+    type DeleteError = anyhow::Error;
+
+    async fn delete(&self, key: String) -> Result<(), Self::DeleteError> {
+        let or = ObjectRef::new(key.as_str()).within(self.resource_manger.namespace().as_str());
+        let mut resource_ref = self.resource_manger.get(or).map_err(|e| anyhow!(e))?;
+        if resource_ref.data.active.contains("false") {
+            return Ok(());
+        }
+        let resource_object = Arc::make_mut(&mut resource_ref);
+        resource_object.data.active = "false".to_string();
+        self.resource_manger.replace(&key, resource_object.clone()).await
+    }
+}
+
+impl UpsertRepositoryWithDelete<String, SchemaFragment> for KubernetesSchemaRepository {}

--- a/src/services/backends/memory.rs
+++ b/src/services/backends/memory.rs
@@ -1,10 +1,27 @@
-use crate::services::base::upsert_repository::UpsertRepository;
+use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
 use anyhow::bail;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
 use tokio::sync::RwLock;
+
+#[async_trait]
+impl<Entity, Key> ReadOnlyRepository<Key, Entity> for RwLock<HashMap<Key, Entity>>
+where
+    Entity: Clone + Send + Sync,
+    Key: Debug + Eq + Hash + Send + Sync,
+{
+    type ReadError = anyhow::Error;
+
+    async fn get(&self, key: Key) -> Result<Entity, Self::ReadError> {
+        let read_guard = self.read().await;
+        match (*read_guard).get(&key) {
+            Some(entity) => Ok(entity.clone()),
+            None => bail!("Entity {:?} not found", key),
+        }
+    }
+}
 
 #[async_trait]
 impl<Entity, Key> UpsertRepository<Key, Entity> for RwLock<HashMap<Key, Entity>>
@@ -14,28 +31,29 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn get(&self, key: Key) -> Result<Entity, Self::Error> {
-        let read_guard = self.read().await;
-        match (*read_guard).get(&key) {
-            Some(entity) => Ok(entity.clone()),
-            None => bail!("Entity {:?} not found", key),
-        }
-    }
-
     async fn upsert(&self, key: Key, entity: Entity) -> Result<(), Self::Error> {
         let mut write_guard = self.write().await;
         (*write_guard).insert(key, entity);
         Ok(())
     }
 
-    async fn delete(&self, key: Key) -> Result<(), Self::Error> {
-        let mut write_guard = self.write().await;
-        (*write_guard).remove(&key);
-        Ok(())
-    }
-
     async fn exists(&self, key: Key) -> Result<bool, Self::Error> {
         let read_guard = self.read().await;
         Ok((*read_guard).get(&key).is_some())
+    }
+}
+
+#[async_trait]
+impl<Key, Entity> CanDelete<Key, Entity> for RwLock<HashMap<Key, Entity>>
+where
+    Entity: Send + Sync + Clone,
+    Key: Send + Sync + Eq + Hash + Debug,
+{
+    type DeleteError = anyhow::Error;
+
+    async fn delete(&self, key: Key) -> Result<(), Self::DeleteError> {
+        let mut write_guard = self.write().await;
+        (*write_guard).remove(&key);
+        Ok(())
     }
 }

--- a/src/services/base/types.rs
+++ b/src/services/base/types.rs
@@ -1,6 +1,7 @@
-use crate::services::base::upsert_repository::UpsertRepository;
+use crate::services::base::upsert_repository::{UpsertRepository, UpsertRepositoryWithDelete};
 use cedar_policy::SchemaFragment;
 
 #[allow(dead_code)]
 /// Represents a repository for schemas
-pub type SchemaRepository = dyn UpsertRepository<String, SchemaFragment, Error = anyhow::Error>;
+pub type SchemaRepository =
+    dyn UpsertRepositoryWithDelete<String, SchemaFragment, ReadError = anyhow::Error, Error = anyhow::Error, DeleteError = anyhow::Error>;

--- a/src/services/base/upsert_repository.rs
+++ b/src/services/base/upsert_repository.rs
@@ -2,18 +2,34 @@ use async_trait::async_trait;
 
 #[async_trait]
 /// Represents a repository for policies
-pub trait UpsertRepository<Key, Entity>: Send + Sync {
-    type Error;
+pub trait ReadOnlyRepository<Key, Entity>: Send + Sync {
+    type ReadError;
 
     /// Retrieves a policy by id
-    async fn get(&self, key: Key) -> Result<Entity, Self::Error>;
+    async fn get(&self, key: Key) -> Result<Entity, Self::ReadError>;
+}
+
+#[async_trait]
+/// Represents a repository for policies
+pub trait CanDelete<Key, Entity>: Send + Sync {
+    type DeleteError;
+
+    /// Retrieves a policy by id
+    async fn delete(&self, key: Key) -> Result<(), Self::DeleteError>;
+}
+
+#[async_trait]
+/// Represents a repository for policies
+pub trait UpsertRepository<Key, Entity>: ReadOnlyRepository<Key, Entity> + Send + Sync {
+    type Error;
 
     /// Updates or inserts a policy by id
     async fn upsert(&self, key: Key, entity: Entity) -> Result<(), Self::Error>;
 
-    /// Deletes policy by id
-    async fn delete(&self, key: Key) -> Result<(), Self::Error>;
-
     /// Checks if an object exists
     async fn exists(&self, key: Key) -> Result<bool, Self::Error>;
+}
+
+pub trait UpsertRepositoryWithDelete<Key, Entity>: UpsertRepository<Key, Entity> + CanDelete<Key, Entity> {
+    // This trait is a marker trait that combines UpsertRepository and CanDelete
 }


### PR DESCRIPTION
Part of #41

Since we use an immutable trie implementation for mapping incoming requests, I don't want to implement the `delete` method.

Additionally, the insertions and readings are handled by different subsystems, and I need two different interfaces for them.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.