### PR TITLE
Implement the ability to load kubeconfig in cluster

### DIFF
--- a/src/services/backends/kubernetes/kubeconfig_loader.rs
+++ b/src/services/backends/kubernetes/kubeconfig_loader.rs
@@ -25,7 +25,7 @@ pub trait KubeConfigLoader: Send + Sync {
     async fn load(&self, source: &Self::ConfigSource) -> anyhow::Result<Config>;
 }
 
-pub trait ParameterLessConfigLoader{
+pub trait ParameterLessConfigLoader {
     fn load(&self) -> anyhow::Result<Config>;
 }
 

--- a/src/services/backends/memory.rs
+++ b/src/services/backends/memory.rs
@@ -1,4 +1,6 @@
-use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
+use crate::services::base::upsert_repository::{
+    CanDelete, ReadOnlyRepository, UpsertRepository, UpsertRepositoryWithDelete,
+};
 use anyhow::bail;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -56,4 +58,11 @@ where
         (*write_guard).remove(&key);
         Ok(())
     }
+}
+
+impl<Entity, Key> UpsertRepositoryWithDelete<Key, Entity> for RwLock<HashMap<Key, Entity>>
+where
+    Entity: Send + Sync + Clone,
+    Key: Send + Sync + Eq + Hash + Debug,
+{
 }


### PR DESCRIPTION
## Scope

Implemented:
- Ability to read Kubernetes config from cluster

Additional changes:
- Added missing interface implementations

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.