### PR TITLE
Implement the resource ownership model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "kube",
  "log",
  "maplit",
+ "regex",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ assert_matches = "1.5.0"
 test-context = "0.4.1"
 actix-web = "4.11.0"
 duration-string = { version = "0.5.2", features = ["serde"] }
+regex = "1.11.1"
 
 [dev-dependencies]
 serde_yml = "0.0.12"

--- a/src/configuration/models/repository_settings.rs
+++ b/src/configuration/models/repository_settings.rs
@@ -1,19 +1,7 @@
-use crate::services::backends::kubernetes::kubernetes_resource_manager::ListenerConfig;
 use duration_string::DurationString;
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct RepositorySettings {
-    pub label_selector_key: String,
-    pub label_selector_value: String,
     pub operation_timeout: DurationString,
-}
-impl Into<ListenerConfig> for &RepositorySettings {
-    fn into(self) -> ListenerConfig {
-        ListenerConfig {
-            label_selector_key: self.label_selector_key.clone(),
-            label_selector_value: self.label_selector_value.clone(),
-            operation_timeout: self.operation_timeout.into(),
-        }
-    }
 }

--- a/src/http/conversions.rs
+++ b/src/http/conversions.rs
@@ -4,6 +4,7 @@ impl From<Status> for actix_web::Error {
     fn from(err: Status) -> Self {
         match err {
             Status::Conflict => actix_web::error::ErrorConflict(err.to_string()),
+            Status::NotOwned(_) => actix_web::error::ErrorConflict(err.to_string()),
             Status::NotFound(_) => actix_web::error::ErrorNotFound(err.to_string()),
             Status::Deleted(_) => actix_web::error::ErrorGone(err.to_string()),
             Status::Timeout(message) => actix_web::error::ErrorRequestTimeout(message),

--- a/src/services/backends/kubernetes/kubernetes_resource_manager.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager.rs
@@ -3,24 +3,24 @@ pub mod spin_lock;
 pub mod status;
 
 use crate::services::backends::kubernetes::kubernetes_resource_manager::object_owner_mark::ObjectOwnerMark;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Conflict, NotOwned};
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_watcher::{
     KubernetesResourceWatcher, ResourceUpdateHandler,
 };
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use async_trait::async_trait;
 use futures::StreamExt;
 use k8s_openapi::NamespaceResourceScope;
 use kube::api::{Patch, PatchParams, PostParams};
 use kube::core::ErrorResponse;
 use kube::runtime::reflector::{ObjectRef, Store};
-use kube::runtime::{reflector, watcher, WatchStreamExt};
+use kube::runtime::{WatchStreamExt, reflector, watcher};
 use kube::{Api, Client, Resource};
 use log::debug;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::hash::Hash;

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
@@ -1,5 +1,7 @@
-use kube::Resource;
+mod tests;
+
 use kube::runtime::watcher::Config;
+use kube::Resource;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 
@@ -38,7 +40,7 @@ impl ObjectOwnerMark {
     }
 
     pub fn get_owner_name(&self) -> String {
-        self.value.clone()
+        self.key.clone()
     }
 }
 

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
@@ -1,5 +1,5 @@
-use kube::runtime::watcher::Config;
 use kube::Resource;
+use kube::runtime::watcher::Config;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
@@ -1,7 +1,7 @@
 mod tests;
 
-use kube::runtime::watcher::Config;
 use kube::Resource;
+use kube::runtime::watcher::Config;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark.rs
@@ -1,0 +1,58 @@
+use kube::runtime::watcher::Config;
+use kube::Resource;
+use maplit::btreemap;
+use std::collections::BTreeMap;
+
+#[derive(Clone, Debug)]
+pub struct ObjectOwnerMark {
+    key: String,
+    value: String,
+}
+
+impl ObjectOwnerMark {
+    pub fn new(key: &str, value: &str) -> Self {
+        ObjectOwnerMark {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
+    pub fn is_owned<S>(&self, object: &S) -> bool
+    where
+        S: Resource,
+    {
+        let labels = object.meta().labels.clone();
+        let owner_label_value = labels.unwrap_or_default().get(&self.key).cloned();
+        owner_label_value.map_or(false, |value| value == self.value)
+    }
+
+    pub fn get_resource_owner<S>(&self, object: &S) -> Option<String>
+    where
+        S: Resource,
+    {
+        object
+            .meta()
+            .labels
+            .clone()
+            .and_then(|labels| labels.get(&self.key).cloned())
+    }
+
+    pub fn get_owner_name(&self) -> String {
+        self.value.clone()
+    }
+}
+
+impl Into<Config> for &ObjectOwnerMark {
+    fn into(self) -> Config {
+        Config {
+            label_selector: Some(format!("{}={}", self.key, self.value)),
+            ..Default::default()
+        }
+    }
+}
+
+impl Into<BTreeMap<String, String>> for &ObjectOwnerMark {
+    fn into(self) -> BTreeMap<String, String> {
+        btreemap! { self.key.clone() => self.value.clone() }
+    }
+}

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark/tests.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/object_owner_mark/tests.rs
@@ -1,0 +1,24 @@
+use crate::services::backends::kubernetes::kubernetes_resource_manager::object_owner_mark::ObjectOwnerMark;
+use crate::services::backends::kubernetes::repositories::schema_repository::schema_document::{
+    SchemaDocument, SchemaDocumentSpec,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use maplit::btreemap;
+
+#[test]
+fn test_object_owner_mark() {
+    let resource = SchemaDocument {
+        metadata: ObjectMeta {
+            labels: Some(btreemap! {"boxer.io".to_string() => "owner".to_string()}),
+            name: Some("name".to_string()),
+            namespace: Some("namespace".to_string()),
+            ..Default::default()
+        },
+        spec: SchemaDocumentSpec::default(),
+    };
+
+    let owner_mark = ObjectOwnerMark::new("boxer.io", "owner");
+
+    assert!(owner_mark.is_owned(&resource));
+    assert_eq!(owner_mark.get_resource_owner(&resource), Some("owner".to_string()));
+}

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/spin_lock.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/spin_lock.rs
@@ -6,8 +6,8 @@ use crate::services::backends::kubernetes::kubernetes_resource_watcher::Kubernet
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use anyhow::Error;
 use kube::runtime::reflector::ObjectRef;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/spin_lock.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/spin_lock.rs
@@ -6,8 +6,8 @@ use crate::services::backends::kubernetes::kubernetes_resource_watcher::Kubernet
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use anyhow::Error;
 use kube::runtime::reflector::ObjectRef;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -30,10 +30,7 @@ where
     }
 
     pub async fn upsert(&self, object_ref: &ObjectRef<R>, resource: R) -> Result<R, Status> {
-        self.resource_manager
-            .upsert_object(object_ref, resource)
-            .await
-            .map_err(Status::from)
+        self.resource_manager.upsert_object(object_ref, resource).await
     }
 
     pub fn get(&self, object_ref: &ObjectRef<R>) -> Result<Arc<R>, Status> {
@@ -42,6 +39,10 @@ where
             None => Err(Status::NotFound(object_ref.into())),
             Some(resource) => Ok(resource),
         }
+    }
+
+    pub async fn force_get(&self, object_ref: &ObjectRef<R>) -> Result<R, Status> {
+        self.resource_manager.force_get(&object_ref).await
     }
 
     pub async fn start<H>(config: KubernetesResourceManagerConfig, update_handler: Arc<H>) -> Result<Self, Error>

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/spin_lock/tests.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/spin_lock/tests.rs
@@ -43,14 +43,8 @@ async fn test_create_object(ctx: &mut SpinLockKubernetesResourceManagerTestConte
 
     assert!(created_object.is_ok());
     let created_object = created_object.unwrap();
-    let labels = created_object.metadata.labels.unwrap();
 
-    assert!(labels.contains_key(ctx.config.listener_config.label_selector_key.as_str()));
-    assert_eq!(
-        labels.get(ctx.config.listener_config.label_selector_key.as_str()),
-        Some(&ctx.config.listener_config.label_selector_value)
-    );
-    assert!(labels.contains_key("repository.boxer.io/test"));
+    assert!(ctx.config.owner_mark.is_owned(&created_object));
 }
 
 #[test_context(SpinLockKubernetesResourceManagerTestContext<SchemaDocument>)]

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/status/not_found_details.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/status/not_found_details.rs
@@ -1,0 +1,37 @@
+use kube::runtime::reflector::ObjectRef;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub struct NotFoundDetails {
+    pub name: String,
+    pub namespace: Option<String>,
+}
+
+impl NotFoundDetails {
+    pub fn new(name: String, namespace: Option<String>) -> Self {
+        NotFoundDetails { name, namespace }
+    }
+}
+
+impl Display for NotFoundDetails {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let namespace = self.namespace.as_deref().unwrap_or("unknown");
+        write!(
+            f,
+            "Resource name: '{}',  namespace '{}' not found",
+            self.name, namespace
+        )
+    }
+}
+
+impl<R> From<&ObjectRef<R>> for NotFoundDetails
+where
+    R: kube::Resource,
+{
+    fn from(object_ref: &ObjectRef<R>) -> Self {
+        NotFoundDetails {
+            name: object_ref.name.clone(),
+            namespace: object_ref.namespace.clone(),
+        }
+    }
+}

--- a/src/services/backends/kubernetes/kubernetes_resource_manager/status/owner_conflict_details.rs
+++ b/src/services/backends/kubernetes/kubernetes_resource_manager/status/owner_conflict_details.rs
@@ -1,0 +1,21 @@
+#[derive(Debug)]
+pub struct OwnerConflictDetails {
+    pub object_name: String,
+    pub object_namespace: Option<String>,
+    pub current_owner: Option<String>,
+}
+
+impl OwnerConflictDetails {
+    pub fn new(object_name: String, object_namespace: Option<String>) -> Self {
+        OwnerConflictDetails {
+            object_name,
+            object_namespace,
+            current_owner: None,
+        }
+    }
+
+    pub fn with_owner(mut self, owner: Option<String>) -> Self {
+        self.current_owner = owner;
+        self
+    }
+}

--- a/src/services/backends/kubernetes/repositories.rs
+++ b/src/services/backends/kubernetes/repositories.rs
@@ -1,19 +1,19 @@
 use crate::services::backends::kubernetes::kubernetes_resource_manager::spin_lock::SpinLockKubernetesResourceManager;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::{
     KubernetesResourceManagerConfig, UpdateLabels,
 };
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
 use async_trait::async_trait;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::NamespaceResourceScope;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::runtime::reflector::ObjectRef;
 use log::debug;
 use regex::Regex;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;

--- a/src/services/backends/kubernetes/repositories.rs
+++ b/src/services/backends/kubernetes/repositories.rs
@@ -1,16 +1,19 @@
 use crate::services::backends::kubernetes::kubernetes_resource_manager::spin_lock::SpinLockKubernetesResourceManager;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::{NotFoundDetails, Status};
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::{
     KubernetesResourceManagerConfig, UpdateLabels,
 };
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
 use async_trait::async_trait;
-use k8s_openapi::NamespaceResourceScope;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::NamespaceResourceScope;
 use kube::runtime::reflector::ObjectRef;
-use serde::Serialize;
+use log::debug;
+use regex::Regex;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -18,6 +21,7 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 pub mod schema_repository;
+mod tests;
 
 pub trait SoftDeleteResource:
     kube::Resource<Scope = NamespaceResourceScope> + Clone + Debug + Serialize + DeserializeOwned + Send + Sync
@@ -42,22 +46,30 @@ where
     }
 }
 
-pub trait IntoObjectRef<R>
+pub trait TryIntoObjectRef<R>
 where
     R: kube::Resource + Send + Sync + 'static,
 {
-    fn into_object_ref(self, namespace: String) -> ObjectRef<R>;
+    type Error;
+
+    fn try_into_object_ref(self, namespace: String) -> Result<ObjectRef<R>, Self::Error>;
 }
 
-impl<R> IntoObjectRef<R> for String
+impl<R> TryIntoObjectRef<R> for String
 where
     R: kube::Resource + Send + Sync + 'static,
     R::DynamicType: Default,
 {
-    fn into_object_ref(self, namespace: String) -> ObjectRef<R> {
-        let mut or = ObjectRef::new(&self);
+    type Error = anyhow::Error;
+
+    fn try_into_object_ref(self, namespace: String) -> Result<ObjectRef<R>, Self::Error> {
+        let only_dns_subdomain = Regex::new(r"[^-a-z0-9]")?;
+        let lowercase_name = self.to_lowercase();
+        let safe_name = only_dns_subdomain.replace_all(&lowercase_name, "-").to_string();
+        let trimmed_name = safe_name.trim_matches('-');
+        let mut or = ObjectRef::new(&trimmed_name);
         or.namespace = Some(namespace);
-        or
+        Ok(or)
     }
 }
 
@@ -86,7 +98,7 @@ where
     R::DynamicType: Hash + Eq + Clone + Default,
 {
     pub async fn start(config: KubernetesResourceManagerConfig) -> anyhow::Result<Self> {
-        let operation_timeout = config.listener_config.operation_timeout;
+        let operation_timeout = config.operation_timeout;
         let resource_manager = SpinLockKubernetesResourceManager::start(config, Arc::new(LoggingUpdateHandler)).await?;
         Ok(KubernetesRepository {
             resource_manager,
@@ -116,13 +128,13 @@ impl<Key, Value, Resource> ReadOnlyRepository<Key, Value> for KubernetesReposito
 where
     Resource: SoftDeleteResource + UpdateLabels,
     Resource::DynamicType: Hash + Eq + Clone + Default,
-    Key: IntoObjectRef<Resource> + Send + Sync + 'static,
+    Key: TryIntoObjectRef<Resource, Error = anyhow::Error> + Send + Sync + 'static,
     Value: TryFromResource<Resource, Error = Status> + Send + Sync + 'static,
 {
     type ReadError = Status;
 
     async fn get(&self, key: Key) -> Result<Value, Self::ReadError> {
-        let object_ref = key.into_object_ref(self.resource_manager.namespace().clone());
+        let object_ref = key.try_into_object_ref(self.resource_manager.namespace().clone())?;
         let resource = self.resource_manager.get(&object_ref);
         match resource {
             Ok(resource) => {
@@ -142,16 +154,16 @@ impl<Key, Value, Resource> CanDelete<Key, Value> for KubernetesRepository<Resour
 where
     Resource: SoftDeleteResource + UpdateLabels,
     Resource::DynamicType: Hash + Eq + Clone + Default,
-    Key: IntoObjectRef<Resource> + Send + Sync + Clone + 'static,
+    Key: TryIntoObjectRef<Resource, Error = anyhow::Error> + Send + Sync + Clone + 'static,
     Value: Send + Sync + 'static,
 {
     type DeleteError = Status;
 
     async fn delete(&self, key: Key) -> Result<(), Self::DeleteError> {
-        let object_ref = key.into_object_ref(self.resource_manager.namespace().clone());
+        let object_ref = key.try_into_object_ref(self.resource_manager.namespace().clone())?;
         let start_time = Instant::now();
         loop {
-            let resource = self.resource_manager.get(&object_ref);
+            let resource = self.resource_manager.force_get(&object_ref).await;
             if let Err(e) = resource {
                 return Err(e);
             }
@@ -161,12 +173,15 @@ where
                 if r.is_deleted() {
                     return Err(Status::Deleted(NotFoundDetails::from(&object_ref)));
                 }
-                let r = Arc::make_mut(&mut r);
                 r.set_deleted();
                 r.clear_managed_fields();
                 let upsert_result = self.resource_manager.upsert(&object_ref, r.clone()).await;
                 if let Ok(_) = upsert_result {
                     return Ok(());
+                }
+                if let Err(Status::NotOwned(details)) = upsert_result {
+                    debug!("Owner conflict: {:?}", details);
+                    return Err(Status::NotOwned(details));
                 }
             }
             self.try_delay(start_time, &object_ref, "delete").await?;
@@ -179,14 +194,14 @@ impl<Key, Value, Resource> UpsertRepository<Key, Value> for KubernetesRepository
 where
     Resource: SoftDeleteResource + UpdateLabels,
     Resource::DynamicType: Hash + Eq + Clone + Default,
-    Key: IntoObjectRef<Resource> + Send + Sync + Clone + 'static,
+    Key: TryIntoObjectRef<Resource, Error = anyhow::Error> + Send + Sync + Clone + 'static,
     Value: ToResource<Resource> + TryFromResource<Resource, Error = Status> + Send + Sync + 'static,
 {
     type Error = Status;
 
     async fn upsert(&self, key: Key, entity: Value) -> Result<(), Self::Error> {
         let start_time = Instant::now();
-        let object_ref = key.into_object_ref(self.resource_manager.namespace().clone());
+        let object_ref = key.try_into_object_ref(self.resource_manager.namespace().clone())?;
         loop {
             let resource = self.resource_manager.get(&object_ref);
 
@@ -198,6 +213,10 @@ where
                         match upsert_result {
                             Ok(_) => return Ok(()),
                             Err(Status::Conflict) => self.try_delay(start_time, &object_ref, "upsert").await?,
+                            Err(Status::NotOwned(details)) => {
+                                debug!("Owner conflict: {:?}", details);
+                                return Err(Status::NotOwned(details));
+                            }
                             Err(e) => return Err(e),
                         }
                     } else {
@@ -223,9 +242,8 @@ where
         }
     }
 
-    async fn exists(&self, key: Key) -> bool {
-        self.resource_manager
-            .get(&key.into_object_ref(self.resource_manager.namespace().clone()))
-            .is_ok()
+    async fn exists(&self, key: Key) -> Result<bool, Self::Error> {
+        let object_ref = key.try_into_object_ref(self.resource_manager.namespace().clone())?;
+        Ok(self.resource_manager.get(&object_ref).is_ok())
     }
 }

--- a/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
@@ -1,20 +1,20 @@
 use super::*;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Deleted, NotOwned};
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Deleted, NotOwned};
+use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_schema::schema;
-use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::testing::api_extensions::{WaitForDelete, WaitForResource};
 use crate::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
 use assert_matches::assert_matches;
+use kube::Api;
 use kube::api::PostParams;
 use kube::runtime::reflector::ObjectRef;
-use kube::Api;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 use std::time::Duration;
-use test_context::{test_context, AsyncTestContext};
+use test_context::{AsyncTestContext, test_context};
 
 const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
@@ -1,19 +1,19 @@
 use super::*;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::Deleted;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::Deleted;
+use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_schema::schema;
-use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::testing::api_extensions::{WaitForDelete, WaitForResource};
 use crate::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
 use assert_matches::assert_matches;
+use kube::Api;
 use kube::api::PostParams;
 use kube::runtime::reflector::ObjectRef;
-use kube::Api;
 use std::collections::BTreeMap;
 use std::time::Duration;
-use test_context::{test_context, AsyncTestContext};
+use test_context::{AsyncTestContext, test_context};
 
 const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
@@ -1,14 +1,19 @@
 use super::*;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::NotFoundDetails;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::Deleted;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_schema::schema;
+use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::testing::api_extensions::{WaitForDelete, WaitForResource};
 use crate::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
 use assert_matches::assert_matches;
+use kube::api::PostParams;
+use kube::runtime::reflector::ObjectRef;
 use kube::Api;
+use std::collections::BTreeMap;
 use std::time::Duration;
-use test_context::{AsyncTestContext, test_context};
+use test_context::{test_context, AsyncTestContext};
 
 const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -16,19 +21,22 @@ struct KubernetesSchemaRepositoryTest {
     repository: Arc<SchemaRepository>,
     api: Api<SchemaDocument>,
     namespace: String,
+    label: String,
 }
 
 impl AsyncTestContext for KubernetesSchemaRepositoryTest {
     async fn setup() -> KubernetesSchemaRepositoryTest {
         let parent = SpinLockKubernetesResourceManagerTestContext::setup().await;
+        let label = parent.config.owner_mark.get_owner_name().clone();
         let repository = Arc::new(KubernetesRepository {
             resource_manager: parent.manager,
-            operation_timeout: parent.config.listener_config.operation_timeout,
+            operation_timeout: parent.config.operation_timeout,
         });
         Self {
             repository,
             api: parent.api_context.api,
             namespace: parent.config.namespace.clone(),
+            label,
         }
     }
 }
@@ -49,9 +57,9 @@ async fn test_create_schema(ctx: &mut KubernetesSchemaRepositoryTest) {
         .expect("Failed to upsert schema");
 
     // Act
-    // ctx.api
-    //     .wait_for_creation(&ObjectRef::new(name), DEFAULT_TEST_TIMEOUT)
-    //     .await;
+    ctx.api
+        .wait_for_creation(name.to_string(), ctx.namespace.to_string(), DEFAULT_TEST_TIMEOUT)
+        .await;
 
     let after = ctx.repository.get(name.to_string()).await;
 
@@ -118,4 +126,147 @@ async fn test_delete_schema(ctx: &mut KubernetesSchemaRepositoryTest) {
 
     // Assert
     assert_matches!(after.unwrap_err(), Deleted(NotFoundDetails { name: _, namespace: _ }));
+}
+
+#[test_context(KubernetesSchemaRepositoryTest)]
+#[tokio::test]
+async fn test_schema_name(ctx: &mut KubernetesSchemaRepositoryTest) {
+    // Arrange
+    let name = "!@test-name-schema--#".to_string();
+    let or: ObjectRef<SchemaDocument> = name.clone().try_into_object_ref(ctx.namespace.clone()).unwrap();
+    let schema_fragment = SchemaFragment::from_json_value(schema()).expect("Failed to create schema fragment");
+
+    // Act
+    ctx.repository
+        .upsert(name.clone(), schema_fragment.clone())
+        .await
+        .expect("Failed to upsert schema");
+    ctx.api
+        .wait_for_creation(or.name.clone(), ctx.namespace.clone(), DEFAULT_TEST_TIMEOUT)
+        .await;
+
+    let after = ctx.repository.get(name.clone()).await;
+
+    // Assert
+    assert!(after.is_ok());
+}
+
+#[test_context(KubernetesSchemaRepositoryTest)]
+#[tokio::test]
+async fn test_schema_no_owner_conflict(ctx: &mut KubernetesSchemaRepositoryTest) {
+    // Arrange
+    let name = "test-not-owned-schema";
+    let schema_str = schema();
+    let schema_fragment = SchemaFragment::from_json_value(schema_str).expect("Failed to create schema fragment");
+
+    let resource = SchemaDocument {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(ctx.namespace.clone()),
+            ..Default::default()
+        },
+        spec: SchemaDocumentSpec::default(),
+    };
+
+    // Act
+    let pp = PostParams {
+        field_manager: Some("test-manager".to_string()),
+        ..Default::default()
+    };
+    ctx.api.create(&pp, &resource).await.unwrap();
+    ctx.api
+        .wait_for_creation(name.to_string(), ctx.namespace.to_string(), DEFAULT_TEST_TIMEOUT)
+        .await;
+
+    let insertion_result = ctx.repository.upsert(name.to_string(), schema_fragment.clone()).await;
+
+    // Assert
+    assert_matches!(
+        insertion_result,
+        Err(Status::NotOwned(OwnerConflictDetails {
+            object_name: _,
+            object_namespace: _,
+            current_owner: None,
+        }))
+    );
+}
+
+#[test_context(KubernetesSchemaRepositoryTest)]
+#[tokio::test]
+async fn test_schema_other_owner_conflict(ctx: &mut KubernetesSchemaRepositoryTest) {
+    // Arrange
+    let name = "test-not-owned-schema";
+    let schema_str = schema();
+    let schema_fragment = SchemaFragment::from_json_value(schema_str).expect("Failed to create schema fragment");
+    let owner = "test-owner".to_string();
+    let resource = SchemaDocument {
+        metadata: ObjectMeta {
+            labels: Some(BTreeMap::from([(ctx.label.clone(), owner.clone())])),
+            name: Some(name.to_string()),
+            namespace: Some(ctx.namespace.clone()),
+            ..Default::default()
+        },
+        spec: SchemaDocumentSpec::default(),
+    };
+
+    // Act
+    let pp = PostParams {
+        field_manager: Some("test-manager".to_string()),
+        ..Default::default()
+    };
+    ctx.api.create(&pp, &resource).await.unwrap();
+    ctx.api
+        .wait_for_creation(name.to_string(), ctx.namespace.to_string(), DEFAULT_TEST_TIMEOUT)
+        .await;
+
+    let insertion_result = ctx.repository.upsert(name.to_string(), schema_fragment.clone()).await;
+
+    // Assert
+    assert_matches!(
+        insertion_result,
+        Err(Status::NotOwned(OwnerConflictDetails {
+            object_name: _,
+            object_namespace: _,
+            current_owner: Some(_),
+        }))
+    );
+}
+
+#[test_context(KubernetesSchemaRepositoryTest)]
+#[tokio::test]
+async fn test_schema_delete_not_owned_resource(ctx: &mut KubernetesSchemaRepositoryTest) {
+    // Arrange
+    let name = "test-not-owned-schema";
+    let owner = "test-owner".to_string();
+    let resource = SchemaDocument {
+        metadata: ObjectMeta {
+            labels: Some(BTreeMap::from([(ctx.label.clone(), owner.clone())])),
+            name: Some(name.to_string()),
+            namespace: Some(ctx.namespace.clone()),
+            ..Default::default()
+        },
+        spec: SchemaDocumentSpec::default(),
+    };
+
+    // Act
+    let pp = PostParams {
+        field_manager: Some("test-manager".to_string()),
+        ..Default::default()
+    };
+    ctx.api.create(&pp, &resource).await.unwrap();
+    ctx.api
+        .wait_for_creation(name.to_string(), ctx.namespace.to_string(), DEFAULT_TEST_TIMEOUT)
+        .await;
+
+    let insertion_result = ctx.repository.delete(name.to_string()).await;
+
+    // Assert
+    assert_matches!(
+        insertion_result,
+        Err(Status::NotOwned(OwnerConflictDetails {
+            object_name: _,
+            object_namespace: _,
+            current_owner: Some(_),
+        }))
+    );
 }

--- a/src/services/backends/kubernetes/repositories/tests.rs
+++ b/src/services/backends/kubernetes/repositories/tests.rs
@@ -1,5 +1,5 @@
-use crate::services::backends::kubernetes::repositories::schema_repository::schema_document::SchemaDocument;
 use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
+use crate::services::backends::kubernetes::repositories::schema_repository::schema_document::SchemaDocument;
 use kube::runtime::reflector::ObjectRef;
 
 #[test]

--- a/src/services/backends/kubernetes/repositories/tests.rs
+++ b/src/services/backends/kubernetes/repositories/tests.rs
@@ -1,0 +1,14 @@
+use crate::services::backends::kubernetes::repositories::schema_repository::schema_document::SchemaDocument;
+use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
+use kube::runtime::reflector::ObjectRef;
+
+#[test]
+fn test_to_object_ref() {
+    let or: ObjectRef<SchemaDocument> = "~~~test-object!!default"
+        .to_string()
+        .try_into_object_ref("default".to_string())
+        .unwrap();
+
+    assert_eq!(or.name, "test-object--default");
+    assert_eq!(or.namespace, Some("default".to_string()));
+}

--- a/src/services/backends/memory.rs
+++ b/src/services/backends/memory.rs
@@ -39,9 +39,9 @@ where
         Ok(())
     }
 
-    async fn exists(&self, key: Key) -> bool {
+    async fn exists(&self, key: Key) -> Result<bool, Self::Error> {
         let read_guard = self.read().await;
-        (*read_guard).get(&key).is_some()
+        Ok((*read_guard).get(&key).is_some())
     }
 }
 

--- a/src/services/base/upsert_repository.rs
+++ b/src/services/base/upsert_repository.rs
@@ -9,7 +9,7 @@ pub trait UpsertRepository<Key, Entity>: ReadOnlyRepository<Key, Entity> + Send 
     async fn upsert(&self, key: Key, entity: Entity) -> Result<(), Self::Error>;
 
     /// Checks if an object exists
-    async fn exists(&self, key: Key) -> bool;
+    async fn exists(&self, key: Key) -> Result<bool, Self::Error>;
 }
 
 #[async_trait]

--- a/src/testing/spin_lock_kubernetes_resource_manager_context.rs
+++ b/src/testing/spin_lock_kubernetes_resource_manager_context.rs
@@ -5,8 +5,8 @@ use crate::services::backends::kubernetes::kubernetes_resource_manager::{
 };
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use crate::testing::api_client_context::ApiClientContext;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -34,7 +34,7 @@ where
         let config = KubernetesResourceManagerConfig {
             namespace: api_context.namespace().to_string(),
             kubeconfig: api_context.config().clone(),
-            owner_mark: ObjectOwnerMark::new("boxer.io", "test-owner"),
+            owner_mark: ObjectOwnerMark::new("boxer.io", "unit-tests"),
             operation_timeout: Duration::from_secs(10),
         };
 

--- a/src/testing/spin_lock_kubernetes_resource_manager_context.rs
+++ b/src/testing/spin_lock_kubernetes_resource_manager_context.rs
@@ -1,11 +1,12 @@
+use crate::services::backends::kubernetes::kubernetes_resource_manager::object_owner_mark::ObjectOwnerMark;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::spin_lock::SpinLockKubernetesResourceManager;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::{
-    KubernetesResourceManagerConfig, ListenerConfig, UpdateLabels,
+    KubernetesResourceManagerConfig, UpdateLabels,
 };
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use crate::testing::api_client_context::ApiClientContext;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -33,12 +34,8 @@ where
         let config = KubernetesResourceManagerConfig {
             namespace: api_context.namespace().to_string(),
             kubeconfig: api_context.config().clone(),
-            field_manager: "boxer".to_string(),
-            listener_config: ListenerConfig {
-                label_selector_key: "repository.boxer.io/test".to_string(),
-                label_selector_value: "test-label".to_string(),
-                operation_timeout: Duration::from_secs(10),
-            },
+            owner_mark: ObjectOwnerMark::new("boxer.io", "test-owner"),
+            operation_timeout: Duration::from_secs(10),
         };
 
         let manager = SpinLockKubernetesResourceManager::start(config.clone(), Arc::new(LoggingUpdateHandler))

--- a/src/testing/spin_lock_kubernetes_resource_manager_context.rs
+++ b/src/testing/spin_lock_kubernetes_resource_manager_context.rs
@@ -5,8 +5,8 @@ use crate::services::backends::kubernetes::kubernetes_resource_manager::{
 };
 use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdateHandler;
 use crate::testing::api_client_context::ApiClientContext;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;


### PR DESCRIPTION
Fixes #29

## Scope

Implemented:
This PR introduces a new resource ownership model. Now, every resource managed by the boxer-issuer or boxer-validator issuer is marked with a label that indicates which service created the resource. If the label does not match the current service's name, the service will not be able to operate on the resource and will return a NotOwned status.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.