### PR TITLE
Make the module try_into_object_ref public

### DIFF
--- a/src/services/backends/kubernetes/repositories.rs
+++ b/src/services/backends/kubernetes/repositories.rs
@@ -1,6 +1,6 @@
 use crate::services::backends::kubernetes::kubernetes_resource_manager::spin_lock::SpinLockKubernetesResourceManager;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::{
     KubernetesResourceManagerConfig, UpdateLabels,
 };
@@ -8,12 +8,12 @@ use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdate
 use crate::services::backends::kubernetes::repositories::try_into_object_ref::TryIntoObjectRef;
 use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
 use async_trait::async_trait;
-use k8s_openapi::NamespaceResourceScope;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use k8s_openapi::NamespaceResourceScope;
 use kube::runtime::reflector::ObjectRef;
 use log::debug;
-use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -22,7 +22,7 @@ use tokio::time::Instant;
 
 pub mod schema_repository;
 mod tests;
-mod try_into_object_ref;
+pub mod try_into_object_ref;
 
 pub trait SoftDeleteResource:
     kube::Resource<Scope = NamespaceResourceScope> + Clone + Debug + Serialize + DeserializeOwned + Send + Sync

--- a/src/services/backends/kubernetes/repositories.rs
+++ b/src/services/backends/kubernetes/repositories.rs
@@ -1,6 +1,6 @@
 use crate::services::backends::kubernetes::kubernetes_resource_manager::spin_lock::SpinLockKubernetesResourceManager;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::{
     KubernetesResourceManagerConfig, UpdateLabels,
 };
@@ -8,12 +8,12 @@ use crate::services::backends::kubernetes::logging_update_handler::LoggingUpdate
 use crate::services::backends::kubernetes::repositories::try_into_object_ref::TryIntoObjectRef;
 use crate::services::base::upsert_repository::{CanDelete, ReadOnlyRepository, UpsertRepository};
 use async_trait::async_trait;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use k8s_openapi::NamespaceResourceScope;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::runtime::reflector::ObjectRef;
 use log::debug;
-use serde::de::DeserializeOwned;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;

--- a/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
@@ -1,20 +1,20 @@
 use super::*;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Deleted, NotOwned};
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Deleted, NotOwned};
+use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_schema::schema;
-use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::testing::api_extensions::{WaitForDelete, WaitForResource};
 use crate::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
 use assert_matches::assert_matches;
+use kube::Api;
 use kube::api::PostParams;
 use kube::runtime::reflector::ObjectRef;
-use kube::Api;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 use std::time::Duration;
-use test_context::{test_context, AsyncTestContext};
+use test_context::{AsyncTestContext, test_context};
 
 const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 

--- a/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
+++ b/src/services/backends/kubernetes/repositories/schema_repository/tests.rs
@@ -1,20 +1,20 @@
 use super::*;
-use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Deleted, NotOwned};
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::not_found_details::NotFoundDetails;
 use crate::services::backends::kubernetes::kubernetes_resource_manager::status::owner_conflict_details::OwnerConflictDetails;
-use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
+use crate::services::backends::kubernetes::kubernetes_resource_manager::status::Status::{Deleted, NotOwned};
 use crate::services::backends::kubernetes::repositories::schema_repository::test_reduced_schema::reduced_schema;
 use crate::services::backends::kubernetes::repositories::schema_repository::test_schema::schema;
+use crate::services::backends::kubernetes::repositories::TryIntoObjectRef;
 use crate::testing::api_extensions::{WaitForDelete, WaitForResource};
 use crate::testing::spin_lock_kubernetes_resource_manager_context::SpinLockKubernetesResourceManagerTestContext;
 use assert_matches::assert_matches;
-use kube::Api;
 use kube::api::PostParams;
 use kube::runtime::reflector::ObjectRef;
+use kube::Api;
 use maplit::btreemap;
 use std::collections::BTreeMap;
 use std::time::Duration;
-use test_context::{AsyncTestContext, test_context};
+use test_context::{test_context, AsyncTestContext};
 
 const DEFAULT_TEST_TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -92,6 +92,10 @@ async fn test_update_schema(ctx: &mut KubernetesSchemaRepositoryTest) {
         .upsert(name.to_string(), reduced_schema_fragment.clone())
         .await
         .expect("Failed to upsert schema");
+
+    ctx.api
+        .wait_for_creation(name.to_string(), ctx.namespace.to_string(), DEFAULT_TEST_TIMEOUT)
+        .await;
 
     let after = ctx.repository.get(name.to_string()).await.unwrap();
 


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/terraform-provider-boxer/issues/25

## Scope

Implemented:
- Make the `try_into_object_ref` public

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.