### PR TITLE
Replace serde_yml with serde_norway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "serde_yml",
+ "serde_norway",
  "test-context",
  "tokio",
  "uuid",
@@ -1797,16 +1797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
-]
-
-[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,6 +2813,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_norway"
+version = "0.9.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
+dependencies = [
+ "indexmap 2.10.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml-norway",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,21 +2880,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serde_yml"
-version = "0.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
-dependencies = [
- "indexmap 2.10.0",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
- "serde",
- "version_check",
 ]
 
 [[package]]
@@ -3540,6 +3528,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "unsafe-libyaml-norway"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39abd59bf32521c7f2301b52d05a6a2c975b6003521cbd0c6dc1582f0a22104"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ maplit = "1.0.2"
 serde_json = "1.0.140"
 uuid = { version = "1.17.0", features = ["v4"] }
 tokio = { version = "1", features = ["full"] }
-serde_yml = "0.0.12"
+serde_norway = "0.9"
 schemars = "0.8.6"
 assert_matches = "1.5.0"
 test-context = "0.4.1"
@@ -40,6 +40,3 @@ opentelemetry-appender-log = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
 opentelemetry-appender-tracing = "0.30.1"
-
-[dev-dependencies]
-serde_yml = "0.0.12"

--- a/src/services/backends/kubernetes/kubeconfig_loader.rs
+++ b/src/services/backends/kubernetes/kubeconfig_loader.rs
@@ -1,9 +1,9 @@
 use anyhow::bail;
 use async_trait::async_trait;
-use kube::Config;
 use kube::config::Kubeconfig;
+use kube::Config;
 use log::{debug, info};
-use serde_yml::from_str;
+use serde_norway::from_str;
 use std::process::Command;
 use std::sync::Arc;
 

--- a/src/services/backends/kubernetes/kubeconfig_loader.rs
+++ b/src/services/backends/kubernetes/kubeconfig_loader.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use async_trait::async_trait;
-use kube::config::Kubeconfig;
 use kube::Config;
+use kube::config::Kubeconfig;
 use log::{debug, info};
 use serde_norway::from_str;
 use std::process::Command;

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -25,7 +25,7 @@ pub async fn get_kubeconfig() -> anyhow::Result<Config> {
     }
     let kubeconfig_string = String::from_utf8(output.stdout)?;
     info!("Kubeconfig used by the tests:\n{}", kubeconfig_string);
-    let kubeconfig: Kubeconfig = serde_yml::from_str(&kubeconfig_string)?;
+    let kubeconfig: Kubeconfig = serde_norway::from_str(&kubeconfig_string)?;
     let config = Config::from_custom_kubeconfig(kubeconfig, &Default::default()).await?;
     Ok(config)
 }


### PR DESCRIPTION
This PR fixes a security issue caused by using serde_yml.

See: https://github.com/SneaksAndData/boxer-core/security/dependabot/4

Additional information about suspicious serde_yml library: https://www.reddit.com/r/rust/comments/1ibdxf9/beware_of_this_guy_making_slop_crates_with_ai/


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.