### PR TITLE
Implement audit event chaining, Part one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ opentelemetry-appender-log = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
 opentelemetry-appender-tracing = "0.30.1"
-pretty_assertions = "1.4.1"
+pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 
 [dev-dependencies]
 mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ opentelemetry-appender-log = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
 opentelemetry-appender-tracing = "0.30.1"
-pretty_assertions = { version = "1.4.1", features = ["unstable"] }
 
 [dev-dependencies]
 mockall = "0.13.1"
+pretty_assertions = { version = "1.4.1", features = ["unstable"] }

--- a/src/services/audit/chained.rs
+++ b/src/services/audit/chained.rs
@@ -1,0 +1,3 @@
+pub mod audit_event;
+pub mod chained_audit_event;
+pub mod token_audit_event;

--- a/src/services/audit/chained/audit_event.rs
+++ b/src/services/audit/chained/audit_event.rs
@@ -1,0 +1,11 @@
+use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+
+#[derive(Debug, Clone)]
+/// [`AuditEvent`] represents the state of the audit information collected during the processing of a request.
+pub enum AuditEvent {
+    /// [`Final`] indicates that the audit information is complete and should not be modified further.
+    Final(ChainedAuditEvent),
+
+    /// [`Intermediate`] indicates that the audit information is still being collected and can be modified.
+    Intermediate(ChainedAuditEvent),
+}

--- a/src/services/audit/chained/chained_audit_event.rs
+++ b/src/services/audit/chained/chained_audit_event.rs
@@ -3,6 +3,10 @@ use crate::services::audit::events::authorization_audit_event::Reason;
 use cedar_policy::Decision;
 use serde::{Deserialize, Serialize};
 
+/// [`ChainedAuditEvent`] represents the information collected during the processing of a
+/// request that is relevant for auditing purposes. It includes details about the external and
+/// internal token validation, the action being performed, the actor, the resource, the
+/// decision made by the authorization engine, and any reasons for that decision.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChainedAuditEvent {
     pub external_token: Option<TokenAuditEvent>,
@@ -26,7 +30,7 @@ impl ChainedAuditEvent {
 }
 
 impl ChainedAuditEvent {
-    pub fn new() -> ChainedAuditEvent {
+    pub fn empty() -> ChainedAuditEvent {
         ChainedAuditEvent {
             external_token: None,
             internal_token: None,

--- a/src/services/audit/chained/event_chain.rs
+++ b/src/services/audit/chained/event_chain.rs
@@ -1,0 +1,40 @@
+use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use crate::services::audit::events::authorization_audit_event::Reason;
+use cedar_policy::Decision;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainedAuditEvent {
+    pub external_token: Option<TokenAuditEvent>,
+    pub internal_token: Option<TokenAuditEvent>,
+
+    pub action: Option<String>,
+    pub actor: Option<String>,
+    pub resource: Option<String>,
+    pub decision: Option<Decision>,
+    pub reason: Option<Reason>,
+}
+
+impl ChainedAuditEvent {
+    pub(crate) fn set_external_token_id(&mut self, token: &str) {
+        self.external_token = Some(TokenAuditEvent::external().with_token_id(token));
+    }
+
+    pub(crate) fn set_external_token_error(&mut self, error: actix_web::Error) {
+        self.external_token = Some(TokenAuditEvent::external().failure(error));
+    }
+}
+
+impl ChainedAuditEvent {
+    pub fn new() -> ChainedAuditEvent {
+        ChainedAuditEvent {
+            external_token: None,
+            internal_token: None,
+            action: None,
+            actor: None,
+            resource: None,
+            decision: None,
+            reason: None,
+        }
+    }
+}

--- a/src/services/audit/chained/token_audit_event.rs
+++ b/src/services/audit/chained/token_audit_event.rs
@@ -1,0 +1,43 @@
+use crate::services::audit::events::token_validation_event::TokenValidationResult;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+/// [`TokenAuditEvent`] represents the audit information related to a token validation,
+/// including the token's ID, the result of the validation, any errors that occurred during
+/// validation, and the type of token (internal or external).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenAuditEvent {
+    pub token_id: Option<String>,
+    pub result: Option<TokenValidationResult>,
+    pub reason_errors: HashSet<String>,
+    pub token_type: Option<String>,
+}
+
+impl TokenAuditEvent {
+    /// Creates a new TokenAuditEvent for an external token validation, with no token ID or errors.
+    pub fn external() -> Self {
+        Self {
+            token_id: None,
+            result: None,
+            reason_errors: HashSet::new(),
+            token_type: Some("external".into()),
+        }
+    }
+
+    /// Adds a token ID to the TokenAuditEvent by computing the MD5 hash of the provided token string.
+    pub fn with_token_id(mut self, token: &str) -> Self {
+        let token_hash = md5::compute(token);
+        self.token_id = Some(format!("md5:{:x}", token_hash));
+        self
+    }
+
+    /// Adds an error to the TokenAuditEvent, setting the token ID to a placeholder value and the
+    /// result to Deny. This method should be used in external token validation when the token is
+    /// not provided or invalid.
+    pub fn failure(mut self, error: actix_web::Error) -> Self {
+        self.token_id = Some("token-not-provided".into());
+        self.result = Some(TokenValidationResult::Deny);
+        self.reason_errors.insert(error.to_string());
+        self
+    }
+}


### PR DESCRIPTION
# Audit Metadata in Boxer

Part of #71
Also related to #70

This task introduces the new Audit architecture in Boxer, which allows to track events from the moment a token 
is issued to the moment it is validated. The architecture consists of three main components:
- The new audit middlewares that are responsible for adding the audit metadata to the request and recording it in the database.
- The new token structure that contains the audit metadata and allows to track events throughout the token lifecycle.
The code will be simplified and the responsibility borders of each component will be clearly defined.

## This pull request
This pull request introduces the data models required by the new Audit Service architecture.

The following sequence diagrams illustrate the flow of the audit metadata in both the token issuance and validation processes.

## Boxer Issue sequence diagram

```mermaid
sequenceDiagram
    User->>+WebserverEndpoint: Token request
    WebserverEndpoint->>+AuditInitializerMiddleware: Passes the raw request
    AuditInitializerMiddleware->>+AuditRecorderMiddleware: Adds the audit metadata
    AuditRecorderMiddleware->>+ExternalTokenMiddleware: Passes the request with the metadata
    ExternalTokenMiddleware->>+TokenValidationService: Adds the external token ID
    TokenValidationService->>+ExternalTokenMiddleware: Returns the validation result and adds to the metadata
    TokenValidationService->>+TokenIssuerService: Adds the audit record to the token
    ExternalTokenMiddleware->>+AuditRecorderMiddleware: (***) Records the audit metadata (with final=false)
    AuditRecorderMiddleware->>+AuditInitializerMiddleware: Returns the token with the updated metadata
    AuditInitializerMiddleware->>+WebserverEndpoint: Passes the request with the updated metadata
    WebserverEndpoint->>+User: Token With Audit Metadata
```

## Boxer Validator sequence diagram
```mermaid
sequenceDiagram
    User->>+WebserverEndpoint: Token With Audit Metadata
    WebserverEndpoint->>+MetadataValidationMiddleware: Passes the request with the metadata
    MetadataValidationMiddleware->>+AuditRecorderMiddleware: Adds the audit metadata
    AuditRecorderMiddleware->>+InternalTokenValidationMiddleware: Checks that token contains the audit metadata
    InternalTokenValidationMiddleware->>+InternalTokenParserMiddleware: Adds the external token ID to the request
    InternalTokenParserMiddleware->>+TokenValidationService: Adds the external token ID to the request
    TokenValidationService->>+InternalTokenParserMiddleware: Adds the action, actor and result
    InternalTokenParserMiddleware->>+InternalTokenValidationMiddleware: Returns the request with the added metadata
    InternalTokenValidationMiddleware->>+AuditRecorderMiddleware: (***) Records the audit metadata (with final=true)
    AuditRecorderMiddleware->>+MetadataValidationMiddleware: Returns the request with the added metadata
    MetadataValidationMiddleware->>+WebserverEndpoint: Passes the request with the added metadata
    WebserverEndpoint->>+User: Validated Token With Audit Metadata
```



## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.