### PR TITLE
Implement audit event chaining, Part two

### DIFF
--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -1,0 +1,74 @@
+pub mod audit_event_source;
+pub mod audit_recorder_factory;
+#[cfg(test)]
+mod tests;
+
+use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+use crate::http::middleware::audit::models::audited_error::AuditedError;
+use crate::services::audit::AuditService;
+use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
+use futures_util::future::LocalBoxFuture;
+use std::sync::Arc;
+
+/// [`AuditRecorder`] is an Actix Web middleware that intercepts incoming requests and outgoing
+/// responses to record audit information using the provided [`AuditService`].
+pub struct AuditRecorder<NextService, Req> {
+    audit_service: Arc<dyn AuditService>,
+    next: Arc<NextService>,
+    phantom: std::marker::PhantomData<Req>,
+}
+
+/// The constructor for the middleware
+impl<NextService, Req: AuditEventSource> AuditRecorder<NextService, Req> {
+    pub fn new(next: Arc<NextService>, audit_service: Arc<dyn AuditService>) -> Self {
+        AuditRecorder {
+            next,
+            audit_service,
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+/// The implementation of the middleware logic, which processes the request and response to record
+/// audit information.
+impl<Next, BodyType, AES> Service<ServiceRequest> for AuditRecorder<Next, AES>
+where
+    Next: Service<ServiceRequest, Response = ServiceResponse<BodyType>, Error = actix_web::Error> + 'static,
+    Next::Future: 'static,
+    BodyType: 'static,
+    AES: for<'a> TryFrom<&'a ServiceResponse<BodyType>, Error = actix_web::Error> + AuditEventSource,
+{
+    type Response = ServiceResponse<BodyType>;
+    type Error = actix_web::Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+    forward_ready!(next);
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let next = Arc::clone(&self.next);
+        let audit_service = Arc::clone(&self.audit_service);
+
+        let future = async move {
+            let result = next.call(req.into()).await;
+
+            match result {
+                Ok(response) => {
+                    let audited: AES = AES::try_from(&response)?;
+                    audit_service.audit(audited.audit_event(), true);
+                    Ok(response)
+                }
+
+                Err(error) => {
+                    match error.as_error::<AuditedError>() {
+                        Some(audited_error) => audit_service.audit(audited_error.event.clone(), false),
+                        None => panic!(
+                            "Error without audit should not reach audit recorder middleware: {:?}",
+                            error
+                        ),
+                    };
+                    Err(error)
+                }
+            }
+        };
+        Box::pin(future)
+    }
+}

--- a/src/http/middleware/audit/audit_recorder/audit_event_source.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_event_source.rs
@@ -1,0 +1,9 @@
+use crate::services::audit::chained::audit_event::AuditEvent;
+
+/// [`AuditEventSource`] is a trait that defines a source of audit events.
+/// It provides a method to retrieve the current audit event, which can be used by
+/// the [`AuditRecorder`] middleware to record audit information for incoming requests.
+pub trait AuditEventSource {
+    /// Retrieves the current audit event.
+    fn audit_event(&self) -> AuditEvent;
+}

--- a/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
@@ -1,0 +1,50 @@
+use crate::http::middleware::audit::audit_recorder::AuditRecorder;
+use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+use crate::services::audit::AuditService;
+use crate::services::audit::log_audit_service::LogAuditService;
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use futures_util::future::LocalBoxFuture;
+use std::sync::Arc;
+
+/// Middleware for audit logging factory
+pub struct AuditRecorderFactory<AES> {
+    pub audit_service: Arc<dyn AuditService>,
+    phantom: std::marker::PhantomData<AES>,
+}
+
+impl<AES> AuditRecorderFactory<AES> {
+    pub fn new(audit_service: Arc<dyn AuditService>) -> Self {
+        AuditRecorderFactory {
+            audit_service,
+            phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<AES> Default for AuditRecorderFactory<AES> {
+    fn default() -> Self {
+        Self::new(Arc::new(LogAuditService::new()))
+    }
+}
+
+/// Transform trait implementation
+/// `NextServiceType` - type of the next service
+/// `BodyType` - type of response's body
+impl<NextService, BodyType, AES> Transform<NextService, ServiceRequest> for AuditRecorderFactory<AES>
+where
+    NextService: Service<ServiceRequest, Response = ServiceResponse<BodyType>, Error = actix_web::Error> + 'static,
+    NextService::Future: 'static,
+    BodyType: 'static,
+    AES: for<'a> TryFrom<&'a ServiceResponse<BodyType>, Error = actix_web::Error> + AuditEventSource,
+{
+    type Response = ServiceResponse<BodyType>;
+    type Error = actix_web::Error;
+    type Transform = AuditRecorder<NextService, AES>;
+    type InitError = ();
+    type Future = LocalBoxFuture<'static, Result<AuditRecorder<NextService, AES>, Self::InitError>>;
+
+    fn new_transform(&self, service: NextService) -> Self::Future {
+        let audit_service = self.audit_service.clone();
+        Box::pin(async move { Ok(AuditRecorder::new(Arc::new(service), audit_service)) })
+    }
+}

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -1,0 +1,88 @@
+use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+use crate::http::middleware::audit::audit_recorder::audit_recorder_factory::AuditRecorderFactory;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
+use crate::services::audit::events::resource_delete_audit_event::ResourceDeleteAuditEvent;
+use crate::services::audit::events::resource_modification_audit_event::ResourceModificationAuditEvent;
+use crate::services::audit::events::token_validation_event::TokenValidationEvent;
+use crate::services::audit::AuditService;
+use actix_web::dev::ServiceResponse;
+use actix_web::error::ErrorInternalServerError;
+use actix_web::{test, web, App, Error, HttpResponse};
+use anyhow::Result;
+use mockall::mock;
+use std::sync::Arc;
+
+#[actix_web::test]
+async fn test_audit_success() {
+    // Arrange
+    let mut audit = MockAuditService::new();
+    audit.expect_audit().returning(|_event, _final| ());
+
+    let chain = App::new()
+        .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
+        .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
+
+    let service = test::init_service(chain).await;
+    let request = test::TestRequest::get().uri("/any-route").to_request();
+
+    // Act
+    let _ = test::call_service(&service, request).await;
+
+    // Expectations are verified automatically when `mock_audit` is dropped at the end of the scope.
+}
+
+#[actix_web::test]
+async fn test_audit_error() {
+    // Arrange
+    let mut audit = MockAuditService::new();
+    audit.expect_audit().returning(|_event, _final| ());
+
+    let chain = App::new()
+        .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
+        .default_service(web::to(|| async move {
+            Result::<HttpResponse, Error>::Err(ErrorInternalServerError("Some error"))
+        }));
+
+    let service = test::init_service(chain).await;
+    let request = test::TestRequest::get().uri("/any-route").to_request();
+
+    // Act
+
+    let _ = test::call_service(&service, request).await;
+
+    // Expectations are verified automatically when `mock_audit` is dropped at the end of the scope.
+}
+
+mock! {
+    pub AuditEventSource {}
+
+    impl AuditEventSource for AuditEventSource {
+        fn audit_event(&self) -> AuditEvent;
+    }
+}
+
+impl<B> TryFrom<&ServiceResponse<B>> for MockAuditEventSource {
+    type Error = actix_web::Error;
+
+    fn try_from(_value: &ServiceResponse<B>) -> Result<Self, Self::Error> {
+        let mut mock = MockAuditEventSource::new();
+        mock.expect_audit_event()
+            .returning(|| AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+        Ok(mock)
+    }
+}
+
+mock! {
+
+    pub AuditService {}
+
+    impl AuditService for AuditService {
+        fn audit(&self, event: AuditEvent, success: bool);
+        fn record_authorization(&self, event: AuthorizationAuditEvent) -> Result<()>;
+        fn record_resource_deletion(&self, event: ResourceDeleteAuditEvent) -> Result<()>;
+        fn record_resource_modification(&self, event: ResourceModificationAuditEvent) -> Result<()>;
+        fn record_token_validation(&self, event: TokenValidationEvent) -> Result<()>;
+    }
+}

--- a/src/services/audit/chained/audit_event.rs
+++ b/src/services/audit/chained/audit_event.rs
@@ -1,7 +1,7 @@
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 
-#[derive(Debug, Clone)]
 /// [`AuditEvent`] represents the state of the audit information collected during the processing of a request.
+#[derive(Debug, Clone)]
 pub enum AuditEvent {
     /// [`Final`] indicates that the audit information is complete and should not be modified further.
     Final(ChainedAuditEvent),

--- a/src/services/audit/chained/audit_event.rs
+++ b/src/services/audit/chained/audit_event.rs
@@ -1,7 +1,7 @@
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 
-/// [`AuditEvent`] represents the state of the audit information collected during the processing of a request.
 #[derive(Debug, Clone)]
+/// [`AuditEvent`] represents the state of the audit information collected during the processing of a request.
 pub enum AuditEvent {
     /// [`Final`] indicates that the audit information is complete and should not be modified further.
     Final(ChainedAuditEvent),


### PR DESCRIPTION
Part of #71
Also related to #70

## Scope

This pull request implements the AuditRecorder middleware for the new audit service


## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.