### PR TITLE
Implement audit event chaining, Part four

### DIFF
--- a/src/http/middleware/audit/begin_audit_chain.rs
+++ b/src/http/middleware/audit/begin_audit_chain.rs
@@ -1,0 +1,20 @@
+#[cfg(test)]
+mod tests;
+mod try_create_audit_context;
+
+use actix_web::body::MessageBody;
+use actix_web::dev::{ServiceRequest, ServiceResponse};
+use actix_web::middleware::Next;
+use actix_web::Error;
+use try_create_audit_context::TryCreateAuditContext;
+
+/// Middleware to initialize the audit chain for incoming requests.
+/// This should be the first middleware in the audit chain to ensure that all subsequent middleware
+/// and handlers have access to the audit context.
+pub async fn begin_audit_chain<AuditContext: TryCreateAuditContext>(
+    req: ServiceRequest,
+    next: Next<impl MessageBody>,
+) -> Result<ServiceResponse<impl MessageBody>, Error> {
+    let audited_request = AuditContext::try_create_audit_context(req)?;
+    next.call(audited_request.into()).await
+}

--- a/src/http/middleware/audit/begin_audit_chain/tests.rs
+++ b/src/http/middleware/audit/begin_audit_chain/tests.rs
@@ -1,0 +1,46 @@
+use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
+use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use actix_web::dev::ServiceRequest;
+use actix_web::middleware::from_fn;
+use actix_web::{test, web, App, HttpResponse};
+use mockall::mock;
+
+#[actix_web::test]
+async fn test_begin_audit_chain() {
+    // Arrange
+    let ctx = MockAuditContext::try_create_audit_context_context();
+
+    // Set expectations on the static creation method
+    ctx.expect().once().returning_st(|request| {
+        let mut mock_instance = MockAuditContext::new();
+
+        // Set expectations on the instance methods (like `Into<ServiceRequest>`)
+        mock_instance.expect_into().once().return_once_st(move || request);
+
+        Ok(mock_instance)
+    });
+
+    let chain = App::new()
+        .wrap(from_fn(begin_audit_chain::<MockAuditContext>)) // Called first
+        .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
+
+    let service = test::init_service(chain).await;
+    let request = test::TestRequest::get().uri("/any-route").to_request();
+
+    // Act
+    let _ = test::call_service(&service, request).await;
+
+    // Expectations are verified automatically when `mock_audit` is dropped at the end of the scope.
+}
+
+mock! {
+    pub AuditContext {}
+
+    impl TryCreateAuditContext for AuditContext {
+        fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error>;
+    }
+
+    impl Into<ServiceRequest> for AuditContext {
+        fn into(self) -> ServiceRequest;
+    }
+}

--- a/src/http/middleware/audit/begin_audit_chain/try_create_audit_context.rs
+++ b/src/http/middleware/audit/begin_audit_chain/try_create_audit_context.rs
@@ -1,0 +1,12 @@
+use actix_web::dev::ServiceRequest;
+
+/// This trait defines the contract for initializing the audit chain. It abstracts the logic of
+/// creating the initial audit context from the incoming request. The implementations of this trait
+/// should return an error if the audit chain cannot be initialized or if the request already
+/// contains an audit context, preventing the creation of multiple audit contexts for the same request.
+pub trait TryCreateAuditContext: Into<ServiceRequest> {
+    /// Attempts to create a new audit context from the incoming request. If the request already contains
+    fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error>
+    where
+        Self: Sized;
+}


### PR DESCRIPTION
Part of #71
Also related to #70

## Scope


This PR introduces the `begin_audit_chain` audit chain middleware that is responsible for creating the new audit context for the HTTP pipeline.

Fixes/Implements #<issue number>.


## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.