### PR TITLE
Implement audit event chaining, Part five

### DIFF
--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -1,0 +1,42 @@
+#[cfg(test)]
+mod tests;
+
+use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use actix_web::dev::ServiceRequest;
+use actix_web::error::ErrorInternalServerError;
+use actix_web::HttpMessage;
+
+/// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
+/// processed by the `begin_audit_chain` middleware and has an audit context initialized.
+/// This struct is used to ensure that the audit context is properly initialized and to prevent
+/// multiple initializations of the audit context for the same request.
+#[derive(Debug)]
+struct AuditedRequest(ServiceRequest);
+
+/// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
+/// a `ServiceRequest` when passing it to the next middleware or handler in the chain.
+impl Into<ServiceRequest> for AuditedRequest {
+    fn into(self) -> ServiceRequest {
+        self.0
+    }
+}
+
+/// The `TryCreateAuditContext` trait is implemented for `AuditedRequest` to define the logic for
+/// creating an audit context from a `ServiceRequest`. The implementation checks if the request
+/// already contains an `AuditEvent` in its extensions, which would indicate that an audit context
+/// has already been initialized.
+impl TryCreateAuditContext for AuditedRequest {
+    fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error> {
+        if request.extensions().get::<AuditEvent>().is_some() {
+            return Err(ErrorInternalServerError(
+                "Failed to create audited request: audit chain already exists in request extensions",
+            ));
+        }
+        request
+            .extensions_mut()
+            .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+        Ok(AuditedRequest(request))
+    }
+}

--- a/src/http/middleware/audit/audited_request/tests.rs
+++ b/src/http/middleware/audit/audited_request/tests.rs
@@ -1,0 +1,42 @@
+use crate::http::middleware::audit::audited_request::AuditedRequest;
+use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use actix_web::dev::ServiceRequest;
+use actix_web::test::TestRequest;
+use actix_web::HttpMessage;
+use pretty_assertions::assert_matches;
+
+#[test]
+fn test_audit_event_initialization() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+
+    // Act
+    let result = AuditedRequest::try_create_audit_context(request);
+
+    // Assert
+    assert_matches!(result, Ok(_));
+    let service_request: ServiceRequest = result.unwrap().into();
+    let audit_event = service_request.extensions().get::<AuditEvent>().cloned();
+    assert_eq!(audit_event.is_some(), true);
+}
+
+#[test]
+fn test_audit_event_double_initialization() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+
+    // Act
+    let request: ServiceRequest = AuditedRequest::try_create_audit_context(request).unwrap().into();
+    let result = AuditedRequest::try_create_audit_context(request);
+
+    // Assert
+    assert_matches!(result, Err(_));
+    assert_eq!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to create audited request:"),
+        true
+    );
+}

--- a/src/http/middleware/audit/begin_audit_chain.rs
+++ b/src/http/middleware/audit/begin_audit_chain.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests;
-mod try_create_audit_context;
+pub mod try_create_audit_context;
 
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};

--- a/src/services/audit/events/authorization_audit_event.rs
+++ b/src/services/audit/events/authorization_audit_event.rs
@@ -1,8 +1,8 @@
 use cedar_policy::{Decision, Diagnostics, EntityUid, Response};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AuthorizationAuditEvent {
     pub action: String,
     pub actor: String,
@@ -11,7 +11,7 @@ pub struct AuthorizationAuditEvent {
     pub reason: Reason,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Reason {
     pub policies: HashSet<String>,
     pub errors: HashSet<String>,

--- a/src/services/audit/events/token_validation_event.rs
+++ b/src/services/audit/events/token_validation_event.rs
@@ -54,7 +54,7 @@ impl TokenValidationEvent {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum TokenValidationResult {
     Allow,


### PR DESCRIPTION
Part of #71
Also related to #70

## Scope

Implemented the `audited_request` struct that implements TryCreateAuditContext for the audit chain initializer module.
## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.