### PR TITLE
Implement audit event chaining, Part six

### DIFF
--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -1,10 +1,12 @@
 pub mod audit_event_source;
 pub mod audit_recorder_factory;
+pub mod audit_writer;
 #[cfg(test)]
 mod tests;
 
+use super::audited_error::AuditedError;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
-use crate::http::middleware::audit::models::audited_error::AuditedError;
+use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use crate::services::audit::AuditService;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use futures_util::future::LocalBoxFuture;
@@ -13,14 +15,14 @@ use std::sync::Arc;
 /// [`AuditRecorder`] is an Actix Web middleware that intercepts incoming requests and outgoing
 /// responses to record audit information using the provided [`AuditService`].
 pub struct AuditRecorder<NextService, Req> {
-    audit_service: Arc<dyn AuditService>,
+    audit_service: Arc<dyn AuditWriter>,
     next: Arc<NextService>,
     phantom: std::marker::PhantomData<Req>,
 }
 
 /// The constructor for the middleware
 impl<NextService, Req: AuditEventSource> AuditRecorder<NextService, Req> {
-    pub fn new(next: Arc<NextService>, audit_service: Arc<dyn AuditService>) -> Self {
+    pub fn new(next: Arc<NextService>, audit_service: Arc<dyn AuditWriter>) -> Self {
         AuditRecorder {
             next,
             audit_service,
@@ -45,7 +47,7 @@ where
 
     fn call(&self, req: ServiceRequest) -> Self::Future {
         let next = Arc::clone(&self.next);
-        let audit_service = Arc::clone(&self.audit_service);
+        let audit_writer = Arc::clone(&self.audit_service);
 
         let future = async move {
             let result = next.call(req.into()).await;
@@ -53,13 +55,13 @@ where
             match result {
                 Ok(response) => {
                     let audited: AES = AES::try_from(&response)?;
-                    audit_service.audit(audited.audit_event(), true);
+                    audit_writer.write(audited.audit_event());
                     Ok(response)
                 }
 
                 Err(error) => {
                     match error.as_error::<AuditedError>() {
-                        Some(audited_error) => audit_service.audit(audited_error.event.clone(), false),
+                        Some(audited_error) => audit_writer.write(audited_error.event.clone()),
                         None => panic!(
                             "Error without audit should not reach audit recorder middleware: {:?}",
                             error

--- a/src/http/middleware/audit/audit_recorder/audit_writer.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_writer.rs
@@ -1,0 +1,8 @@
+use crate::services::audit::chained::audit_event::AuditEvent;
+
+/// The `AuditWriter` trait defines the contract for writing audit events. It abstracts the logic of
+/// persisting or transmitting audit events to the desired destination.
+pub trait AuditWriter: Send + Sync + 'static {
+    /// Writes the given `AuditEvent` to the configured audit destination.
+    fn write(&self, event: AuditEvent);
+}

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -126,6 +126,8 @@ async fn test_custom_error_recording() {
 
     // Act
     let result = test::try_call_service(&service, request).await;
+
+    // Assert
     let err = result.expect_err("Expected service call to fail with an error");
     let audited_err = err
         .as_error::<AuditedError>()
@@ -137,8 +139,6 @@ async fn test_custom_error_recording() {
             ..
         }
     );
-
-    // The code above should panic.
 }
 
 mock! {

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -1,24 +1,24 @@
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_recorder_factory::AuditRecorderFactory;
+use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
+use crate::http::middleware::audit::audited_error::AuditedError;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
-use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
-use crate::services::audit::events::resource_delete_audit_event::ResourceDeleteAuditEvent;
-use crate::services::audit::events::resource_modification_audit_event::ResourceModificationAuditEvent;
-use crate::services::audit::events::token_validation_event::TokenValidationEvent;
-use crate::services::audit::AuditService;
+use actix_web::body::BoxBody;
+use actix_web::dev::Service;
 use actix_web::dev::ServiceResponse;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::{test, web, App, Error, HttpResponse};
+use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
 use anyhow::Result;
 use mockall::mock;
+use pretty_assertions::assert_matches;
 use std::sync::Arc;
 
 #[actix_web::test]
 async fn test_audit_success() {
     // Arrange
-    let mut audit = MockAuditService::new();
-    audit.expect_audit().returning(|_event, _final| ());
+    let mut audit = MockAuditWriter::new();
+    audit.expect_write().returning(|_| ());
 
     let chain = App::new()
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
@@ -36,8 +36,8 @@ async fn test_audit_success() {
 #[actix_web::test]
 async fn test_audit_error() {
     // Arrange
-    let mut audit = MockAuditService::new();
-    audit.expect_audit().returning(|_event, _final| ());
+    let mut audit = MockAuditWriter::new();
+    audit.expect_write().returning(|_| ());
 
     let chain = App::new()
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
@@ -53,6 +53,92 @@ async fn test_audit_error() {
     let _ = test::call_service(&service, request).await;
 
     // Expectations are verified automatically when `mock_audit` is dropped at the end of the scope.
+}
+
+#[actix_web::test]
+#[should_panic(expected = "Error without audit should not reach audit recorder middleware: \"Some error\"")]
+async fn test_custom_error_without_error_event() {
+    // Arrange
+    let mut audit = MockAuditWriter::new();
+    audit.expect_write().returning(|_| ());
+
+    let chain = App::new()
+        .wrap_fn(|_req, _srv| {
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(ErrorInternalServerError(
+                "Some error",
+            )))
+        })
+        .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
+        .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
+
+    let service = test::init_service(chain).await;
+    let request = test::TestRequest::get().uri("/any-route").to_request();
+
+    // Act
+
+    let _: ServiceResponse<BoxBody> = test::call_service(&service, request).await;
+
+    // The code above should panic.
+}
+
+#[actix_web::test]
+#[should_panic(expected = "Attempt to wrap an error without an audit event")]
+async fn test_custom_error_panic_request_without_event() {
+    // Arrange
+    let mut audit = MockAuditWriter::new();
+    audit.expect_write().returning(|_| ());
+
+    let chain = App::new()
+        .wrap_fn(|req, _src| {
+            let error = AuditedError::wrap_req(req, ErrorInternalServerError("Some error"));
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(actix_web::Error::from(error)))
+        })
+        .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
+        .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
+
+    let service = test::init_service(chain).await;
+    let request = test::TestRequest::get().uri("/any-route").to_request();
+
+    // Act
+    let _: ServiceResponse<BoxBody> = test::call_service(&service, request).await;
+
+    // The code above should panic.
+}
+
+#[actix_web::test]
+async fn test_custom_error_recording() {
+    // Arrange
+    let mut audit = MockAuditWriter::new();
+    audit.expect_write().returning(|_| ());
+
+    let chain = App::new()
+        .wrap_fn(|req, _src| {
+            req.extensions_mut()
+                .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+            let error = AuditedError::wrap_req(req, ErrorInternalServerError("Some error"));
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(actix_web::Error::from(error)))
+        })
+        .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
+        .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
+
+    let service = test::init_service(chain).await;
+    let request = test::TestRequest::get().uri("/any-route").to_request();
+
+    // Act
+    let result = test::try_call_service(&service, request).await;
+    let err = result.expect_err("Expected service call to fail with an error");
+    let audited_err = err
+        .as_error::<AuditedError>()
+        .expect("Expected error to be downcastable to AuditedError");
+    assert_matches!(
+        audited_err,
+        AuditedError {
+            event: AuditEvent::Intermediate(_),
+            ..
+        }
+    );
+
+    // The code above should panic.
 }
 
 mock! {
@@ -76,13 +162,9 @@ impl<B> TryFrom<&ServiceResponse<B>> for MockAuditEventSource {
 
 mock! {
 
-    pub AuditService {}
+    pub AuditWriter {}
 
-    impl AuditService for AuditService {
-        fn audit(&self, event: AuditEvent, success: bool);
-        fn record_authorization(&self, event: AuthorizationAuditEvent) -> Result<()>;
-        fn record_resource_deletion(&self, event: ResourceDeleteAuditEvent) -> Result<()>;
-        fn record_resource_modification(&self, event: ResourceModificationAuditEvent) -> Result<()>;
-        fn record_token_validation(&self, event: TokenValidationEvent) -> Result<()>;
+    impl AuditWriter for AuditWriter {
+        fn write(&self, event: AuditEvent);
     }
 }

--- a/src/http/middleware/audit/audited_error.rs
+++ b/src/http/middleware/audit/audited_error.rs
@@ -1,0 +1,62 @@
+use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use actix_web::dev::ServiceRequest;
+use actix_web::error::InternalError;
+use actix_web::http::StatusCode;
+use actix_web::{HttpMessage, ResponseError};
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+
+/// [`AuditedError`] is a wrapper for any error that implements `ResponseError` and carries
+/// an associated [`AuditEvent`] that can be recorded by the audit middleware.
+#[derive(Debug)]
+pub struct AuditedError {
+    pub event: AuditEvent,
+    cause: Box<dyn ResponseError>,
+}
+
+impl AuditedError {
+    /// Wraps a given `ResponseError` into an `AuditedError`, extracting the associated
+    /// `AuditEvent` from the error's response extensions.
+    pub fn wrap(cause: impl ResponseError + 'static) -> AuditedError {
+        let event = cause
+            .error_response()
+            .extensions()
+            .get::<AuditEvent>()
+            .expect("Attempt to wrap an error without an audit event")
+            .clone();
+        AuditedError {
+            event,
+            cause: Box::new(cause),
+        }
+    }
+
+    /// Similar to `wrap` but extracts the `AuditEvent` from the request's extensions instead of
+    /// the error's response.
+    pub fn wrap_req(request: ServiceRequest, cause: impl Error + 'static) -> AuditedError {
+        let event = request
+            .extensions()
+            .get::<AuditEvent>()
+            .expect("Attempt to wrap an error without an audit event")
+            .clone();
+        AuditedError {
+            event,
+            cause: Box::new(InternalError::new(cause, StatusCode::INTERNAL_SERVER_ERROR)),
+        }
+    }
+}
+
+/// The `Display` implementation for `AuditedError` simply formats the contained `AuditEvent`
+/// for debugging purposes.
+impl Display for AuditedError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{:?}", self.event))
+    }
+}
+
+/// The `ResponseError` implementation for `AuditedError` delegates to the underlying cause's
+impl ResponseError for AuditedError {
+    fn error_response(&self) -> actix_web::HttpResponse {
+        self.cause.error_response()
+    }
+}


### PR DESCRIPTION
Part of #71
Also related to #70

Implemented:
- Added more unit tests
- Added the `AuditedError` wrapper
- Replaced dependency on `AuditService` with the dependency on the new trait `AuditWriter`


## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.