### PR TITLE
Implement audit event chaining, Part 7

### DIFF
--- a/src/http/middleware.rs
+++ b/src/http/middleware.rs
@@ -1,1 +1,2 @@
+pub mod audit;
 pub mod logging;

--- a/src/http/middleware/audit.rs
+++ b/src/http/middleware/audit.rs
@@ -1,0 +1,4 @@
+pub mod audit_recorder;
+pub mod audited_error;
+pub mod audited_request;
+pub mod begin_audit_chain;

--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -7,7 +7,6 @@ mod tests;
 use super::audited_error::AuditedError;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use crate::services::audit::AuditService;
 use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;

--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -7,7 +7,7 @@ mod tests;
 use super::audited_error::AuditedError;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;
 

--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -7,7 +7,7 @@ mod tests;
 use super::audited_error::AuditedError;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
+use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;
 

--- a/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
@@ -1,29 +1,22 @@
-use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
-use crate::services::audit::AuditService;
-use crate::services::audit::log_audit_service::LogAuditService;
+use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
+use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;
 
 /// Middleware for audit logging factory
 pub struct AuditRecorderFactory<AES> {
-    pub audit_service: Arc<dyn AuditService>,
+    pub audit_service: Arc<dyn AuditWriter>,
     phantom: std::marker::PhantomData<AES>,
 }
 
 impl<AES> AuditRecorderFactory<AES> {
-    pub fn new(audit_service: Arc<dyn AuditService>) -> Self {
+    pub fn new(audit_service: Arc<dyn AuditWriter>) -> Self {
         AuditRecorderFactory {
             audit_service,
             phantom: std::marker::PhantomData,
         }
-    }
-}
-
-impl<AES> Default for AuditRecorderFactory<AES> {
-    fn default() -> Self {
-        Self::new(Arc::new(LogAuditService::new()))
     }
 }
 

--- a/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
@@ -1,6 +1,6 @@
+use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -11,7 +11,6 @@ use actix_web::{App, Error, HttpMessage, HttpResponse, test, web};
 use anyhow::Result;
 use mockall::mock;
 use pretty_assertions::assert_matches;
-use std::future;
 use std::sync::Arc;
 
 #[actix_web::test]
@@ -64,7 +63,7 @@ async fn test_custom_error_without_error_event() {
 
     let chain = App::new()
         .wrap_fn(|_req, _srv| {
-            future::ready(Err::<ServiceResponse<BoxBody>, _>(ErrorInternalServerError(
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(ErrorInternalServerError(
                 "Some error",
             )))
         })
@@ -91,7 +90,7 @@ async fn test_custom_error_panic_request_without_event() {
     let chain = App::new()
         .wrap_fn(|req, _src| {
             let error = AuditedError::from_request(&req, ErrorInternalServerError("Some error"));
-            future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
         })
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
         .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
@@ -116,7 +115,7 @@ async fn test_custom_error_recording() {
             req.extensions_mut()
                 .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
             let error = AuditedError::from_request(&req, ErrorInternalServerError("Some error"));
-            future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
         })
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
         .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -7,7 +7,7 @@ use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use actix_web::body::BoxBody;
 use actix_web::dev::ServiceResponse;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::{App, Error, HttpMessage, HttpResponse, test, web};
+use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
 use anyhow::Result;
 use mockall::mock;
 use pretty_assertions::assert_matches;

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -7,7 +7,7 @@ use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use actix_web::body::BoxBody;
 use actix_web::dev::ServiceResponse;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
+use actix_web::{App, Error, HttpMessage, HttpResponse, test, web};
 use anyhow::Result;
 use mockall::mock;
 use pretty_assertions::assert_matches;

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -5,7 +5,6 @@ use crate::http::middleware::audit::audited_error::AuditedError;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use actix_web::body::BoxBody;
-use actix_web::dev::Service;
 use actix_web::dev::ServiceResponse;
 use actix_web::error::ErrorInternalServerError;
 use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
@@ -90,8 +89,8 @@ async fn test_custom_error_panic_request_without_event() {
 
     let chain = App::new()
         .wrap_fn(|req, _src| {
-            let error = AuditedError::wrap_req(req, ErrorInternalServerError("Some error"));
-            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(actix_web::Error::from(error)))
+            let error = AuditedError::from_request(req, ErrorInternalServerError("Some error"));
+            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
         })
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
         .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
@@ -115,7 +114,7 @@ async fn test_custom_error_recording() {
         .wrap_fn(|req, _src| {
             req.extensions_mut()
                 .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
-            let error = AuditedError::wrap_req(req, ErrorInternalServerError("Some error"));
+            let error = AuditedError::from_request(req, ErrorInternalServerError("Some error"));
             std::future::ready(Err::<ServiceResponse<BoxBody>, _>(actix_web::Error::from(error)))
         })
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -11,6 +11,7 @@ use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
 use anyhow::Result;
 use mockall::mock;
 use pretty_assertions::assert_matches;
+use std::future;
 use std::sync::Arc;
 
 #[actix_web::test]
@@ -63,7 +64,7 @@ async fn test_custom_error_without_error_event() {
 
     let chain = App::new()
         .wrap_fn(|_req, _srv| {
-            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(ErrorInternalServerError(
+            future::ready(Err::<ServiceResponse<BoxBody>, _>(ErrorInternalServerError(
                 "Some error",
             )))
         })
@@ -89,8 +90,8 @@ async fn test_custom_error_panic_request_without_event() {
 
     let chain = App::new()
         .wrap_fn(|req, _src| {
-            let error = AuditedError::from_request(req, ErrorInternalServerError("Some error"));
-            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
+            let error = AuditedError::from_request(&req, ErrorInternalServerError("Some error"));
+            future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
         })
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
         .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));
@@ -114,8 +115,8 @@ async fn test_custom_error_recording() {
         .wrap_fn(|req, _src| {
             req.extensions_mut()
                 .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
-            let error = AuditedError::from_request(req, ErrorInternalServerError("Some error"));
-            std::future::ready(Err::<ServiceResponse<BoxBody>, _>(actix_web::Error::from(error)))
+            let error = AuditedError::from_request(&req, ErrorInternalServerError("Some error"));
+            future::ready(Err::<ServiceResponse<BoxBody>, _>(Error::from(error)))
         })
         .wrap(AuditRecorderFactory::<MockAuditEventSource>::new(Arc::new(audit)))
         .default_service(web::to(|| async move { HttpResponse::Ok().finish() }));

--- a/src/http/middleware/audit/audited_error.rs
+++ b/src/http/middleware/audit/audited_error.rs
@@ -1,9 +1,12 @@
-use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+#[cfg(test)]
+mod tests;
+
 use crate::services::audit::chained::audit_event::AuditEvent;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::InternalError;
 use actix_web::http::StatusCode;
 use actix_web::{HttpMessage, ResponseError};
+use anyhow::anyhow;
 use std::error::Error;
 use std::fmt::{Debug, Display, Formatter};
 
@@ -33,15 +36,43 @@ impl AuditedError {
 
     /// Similar to `wrap` but extracts the `AuditEvent` from the request's extensions instead of
     /// the error's response.
-    pub fn wrap_req(request: ServiceRequest, cause: impl Error + 'static) -> AuditedError {
+    pub fn from_request(request: &ServiceRequest, cause: impl Error + 'static) -> AuditedError {
         let event = request
             .extensions()
             .get::<AuditEvent>()
             .expect("Attempt to wrap an error without an audit event")
             .clone();
-        AuditedError {
-            event,
-            cause: Box::new(InternalError::new(cause, StatusCode::INTERNAL_SERVER_ERROR)),
+        match event {
+            AuditEvent::Final(_) => {
+                panic!("Final audit event in a request should not be wrapped for an error")
+            }
+            AuditEvent::Intermediate(data) => AuditedError {
+                event: AuditEvent::Intermediate(data),
+                cause: Box::new(InternalError::new(cause, StatusCode::INTERNAL_SERVER_ERROR)),
+            },
+        }
+    }
+
+    pub fn external_token_not_present(request: &ServiceRequest) -> AuditedError {
+        let event = request
+            .extensions()
+            .get::<AuditEvent>()
+            .expect("Attempt to wrap a request for an error without audit event")
+            .clone();
+        match event {
+            AuditEvent::Final(_) => {
+                panic!("Final audit event in a request should not be wrapped for token not present error")
+            }
+            AuditEvent::Intermediate(data) if data.is_empty() => AuditedError {
+                event: AuditEvent::token_not_present(),
+                cause: Box::new(InternalError::new(
+                    anyhow!("Token not present"),
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                )),
+            },
+            AuditEvent::Intermediate(data) => {
+                panic!("Non-empty audit event when token is not present: {:?}", data)
+            }
         }
     }
 }

--- a/src/http/middleware/audit/audited_error.rs
+++ b/src/http/middleware/audit/audited_error.rs
@@ -36,6 +36,12 @@ impl AuditedError {
 
     /// Similar to `wrap` but extracts the `AuditEvent` from the request's extensions instead of
     /// the error's response.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the request does not contain an AuditEvent extension.
+    /// Panics if the contained AuditEvent is AuditEvent::Final, since final
+    /// audit events are not intended to be wrapped as errors.
     pub fn from_request(request: &ServiceRequest, cause: impl Error + 'static) -> AuditedError {
         let event = request
             .extensions()
@@ -53,6 +59,14 @@ impl AuditedError {
         }
     }
 
+    /// Creates an `AuditedError` in case when the external token is not present.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the request does not contain an AuditEvent extension.
+    /// Panics if the contained AuditEvent is AuditEvent::Final, since final
+    /// audit events are not intended to be wrapped as errors.
+    /// Panics if token is not present, but audit event is not empty
     pub fn external_token_not_present(request: &ServiceRequest) -> AuditedError {
         let event = request
             .extensions()

--- a/src/http/middleware/audit/audited_error/tests.rs
+++ b/src/http/middleware/audit/audited_error/tests.rs
@@ -1,0 +1,116 @@
+use crate::http::middleware::audit::audited_error::AuditedError;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use actix_web::error::{ErrorInternalServerError, InternalError};
+use actix_web::http::StatusCode;
+use actix_web::test::TestRequest;
+use actix_web::{HttpMessage, HttpResponse};
+use anyhow::anyhow;
+use assert_matches::assert_matches;
+use pretty_assertions::assert_eq;
+
+#[test]
+#[should_panic(expected = "Attempt to wrap an error without an audit event")]
+fn test_audited_error_wrap_panic() {
+    // Arrange
+
+    // Act
+    AuditedError::wrap(InternalError::new(anyhow!("Error"), StatusCode::INTERNAL_SERVER_ERROR));
+
+    // Assert
+    // Test should panic
+}
+
+#[test]
+fn test_audited_error_wrap_success() {
+    // Arrange
+    let mut response = HttpResponse::build(StatusCode::INTERNAL_SERVER_ERROR).finish();
+    response
+        .extensions_mut()
+        .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+
+    // Act
+    let result = AuditedError::wrap(InternalError::from_response(anyhow!("Error"), response));
+
+    // Assert
+    assert_matches!(result, audited_error => {
+        assert_matches!(audited_error.event, AuditEvent::Intermediate(_));
+        assert_eq!(audited_error.cause.to_string(), "Error");
+    });
+}
+
+#[test]
+#[should_panic(expected = "Attempt to wrap an error without an audit event")]
+fn test_audited_error_from_request_no_audit_event() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+
+    // Act
+    AuditedError::from_request(&request, ErrorInternalServerError("Some error"));
+
+    // Assert
+    // Test should panic
+}
+
+#[test]
+#[should_panic(expected = "Final audit event in a request should not be wrapped for an error")]
+fn test_audited_error_from_request_final_audit_event() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+    request
+        .request()
+        .extensions_mut()
+        .insert(AuditEvent::Final(ChainedAuditEvent::empty()));
+
+    // Act
+    AuditedError::from_request(&request, ErrorInternalServerError("Some error"));
+
+    // Assert
+    // Test should panic
+}
+
+#[test]
+fn test_audited_error_from_request_success() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+    request
+        .request()
+        .extensions_mut()
+        .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+
+    // Act
+    let error = AuditedError::from_request(&request, ErrorInternalServerError("Error"));
+
+    // Assert
+    assert_matches!(error, audited_error => {
+        assert_matches!(audited_error.event, AuditEvent::Intermediate(_));
+        assert_eq!(audited_error.cause.to_string(), "Error");
+    });
+}
+
+#[test]
+fn test_audited_error_external_token_not_present() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+    request
+        .request()
+        .extensions_mut()
+        .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+
+    // Act
+    let error = AuditedError::external_token_not_present(&request);
+
+    // Assert
+    assert_matches!(error, audited_error => {
+        assert_matches!(audited_error.event, AuditEvent::Final(
+            ChainedAuditEvent {
+                external_token: Some(TokenAuditEvent {
+                    reason_errors,
+                    ..
+                }),
+                ..
+            }) if reason_errors.contains("token-not-present"));
+        assert_eq!(audited_error.cause.to_string(), "Token not present");
+    });
+}

--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -4,16 +4,16 @@ mod tests;
 use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::HttpMessage;
 
 /// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.
 /// This struct is used to ensure that the audit context is properly initialized and to prevent
 /// multiple initializations of the audit context for the same request.
 #[derive(Debug)]
-pub struct AuditedRequest(ServiceRequest);
+struct AuditedRequest(ServiceRequest);
 
 /// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
 /// a `ServiceRequest` when passing it to the next middleware or handler in the chain.

--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -13,7 +13,7 @@ use actix_web::HttpMessage;
 /// This struct is used to ensure that the audit context is properly initialized and to prevent
 /// multiple initializations of the audit context for the same request.
 #[derive(Debug)]
-struct AuditedRequest(ServiceRequest);
+pub struct AuditedRequest(ServiceRequest);
 
 /// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
 /// a `ServiceRequest` when passing it to the next middleware or handler in the chain.

--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -4,9 +4,9 @@ mod tests;
 use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::HttpMessage;
 
 /// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.

--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -4,16 +4,16 @@ mod tests;
 use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
-use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
+use actix_web::HttpMessage;
 
 /// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.
 /// This struct is used to ensure that the audit context is properly initialized and to prevent
 /// multiple initializations of the audit context for the same request.
 #[derive(Debug)]
-struct AuditedRequest(ServiceRequest);
+pub struct AuditedRequest(ServiceRequest);
 
 /// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
 /// a `ServiceRequest` when passing it to the next middleware or handler in the chain.

--- a/src/http/middleware/audit/audited_request/tests.rs
+++ b/src/http/middleware/audit/audited_request/tests.rs
@@ -1,9 +1,9 @@
 use crate::http::middleware::audit::audited_request::AuditedRequest;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::services::audit::chained::audit_event::AuditEvent;
-use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::test::TestRequest;
+use actix_web::HttpMessage;
 use pretty_assertions::assert_matches;
 
 #[test]

--- a/src/http/middleware/audit/audited_request/tests.rs
+++ b/src/http/middleware/audit/audited_request/tests.rs
@@ -1,9 +1,9 @@
 use crate::http::middleware::audit::audited_request::AuditedRequest;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::services::audit::chained::audit_event::AuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::test::TestRequest;
-use actix_web::HttpMessage;
 use pretty_assertions::assert_matches;
 
 #[test]

--- a/src/http/middleware/audit/begin_audit_chain.rs
+++ b/src/http/middleware/audit/begin_audit_chain.rs
@@ -2,10 +2,10 @@
 mod tests;
 pub mod try_create_audit_context;
 
+use actix_web::Error;
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::middleware::Next;
-use actix_web::Error;
 use try_create_audit_context::TryCreateAuditContext;
 
 /// Middleware to initialize the audit chain for incoming requests.

--- a/src/http/middleware/audit/begin_audit_chain.rs
+++ b/src/http/middleware/audit/begin_audit_chain.rs
@@ -2,10 +2,10 @@
 mod tests;
 pub mod try_create_audit_context;
 
-use actix_web::Error;
 use actix_web::body::MessageBody;
 use actix_web::dev::{ServiceRequest, ServiceResponse};
 use actix_web::middleware::Next;
+use actix_web::Error;
 use try_create_audit_context::TryCreateAuditContext;
 
 /// Middleware to initialize the audit chain for incoming requests.

--- a/src/http/middleware/audit/begin_audit_chain/tests.rs
+++ b/src/http/middleware/audit/begin_audit_chain/tests.rs
@@ -2,7 +2,7 @@ use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use actix_web::dev::ServiceRequest;
 use actix_web::middleware::from_fn;
-use actix_web::{test, web, App, HttpResponse};
+use actix_web::{App, HttpResponse, test, web};
 use mockall::mock;
 
 #[actix_web::test]

--- a/src/http/middleware/audit/begin_audit_chain/tests.rs
+++ b/src/http/middleware/audit/begin_audit_chain/tests.rs
@@ -2,7 +2,7 @@ use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use actix_web::dev::ServiceRequest;
 use actix_web::middleware::from_fn;
-use actix_web::{App, HttpResponse, test, web};
+use actix_web::{test, web, App, HttpResponse};
 use mockall::mock;
 
 #[actix_web::test]

--- a/src/services/audit/chained/audit_event.rs
+++ b/src/services/audit/chained/audit_event.rs
@@ -1,4 +1,6 @@
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use maplit::hashset;
 
 #[derive(Debug, Clone)]
 /// [`AuditEvent`] represents the state of the audit information collected during the processing of a request.
@@ -8,4 +10,25 @@ pub enum AuditEvent {
 
     /// [`Intermediate`] indicates that the audit information is still being collected and can be modified.
     Intermediate(ChainedAuditEvent),
+}
+
+impl AuditEvent {
+    pub fn token_not_present() -> AuditEvent {
+        AuditEvent::Final(ChainedAuditEvent {
+            external_token: Some(TokenAuditEvent {
+                token_id: None,
+                result: None,
+                reason_errors: hashset! {
+                    "token-not-present".into()
+                },
+                token_type: None,
+            }),
+            internal_token: None,
+            action: None,
+            actor: None,
+            resource: None,
+            decision: None,
+            reason: None,
+        })
+    }
 }

--- a/src/services/audit/chained/chained_audit_event.rs
+++ b/src/services/audit/chained/chained_audit_event.rs
@@ -20,6 +20,7 @@ pub struct ChainedAuditEvent {
 }
 
 impl ChainedAuditEvent {
+    /// Creates a new empty `ChainedAuditEvent` with all fields set to `None`.
     pub fn empty() -> ChainedAuditEvent {
         ChainedAuditEvent {
             external_token: None,
@@ -30,5 +31,16 @@ impl ChainedAuditEvent {
             decision: None,
             reason: None,
         }
+    }
+
+    /// Checks if the `ChainedAuditEvent` is empty
+    pub fn is_empty(&self) -> bool {
+        self.external_token.is_none()
+            && self.internal_token.is_none()
+            && self.action.is_none()
+            && self.actor.is_none()
+            && self.resource.is_none()
+            && self.decision.is_none()
+            && self.reason.is_none()
     }
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71
Also related to https://github.com/SneaksAndData/boxer-core/issues/70

## Scope

Implemented:
- Fixed dependency of `AuditRecorderFactory`
- Renamed `wrap_req` to `from_request`
- Added the `external_token_not_present` constructor for `AuditedError` struct
- Improved unit testing
- Fixed formatting issues

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.