### PR TITLE
Move the ExternalToken struct to boxer-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pretty_assertions",
  "regex",
+ "rstest",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -1038,6 +1039,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,7 +1131,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1137,7 +1150,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1160,6 +1173,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "headers"
@@ -1519,13 +1538,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.17.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2321,7 +2341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2452,6 +2472,15 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -2613,6 +2642,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2658,6 +2693,35 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2954,7 +3018,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "ryu",
@@ -2967,7 +3031,7 @@ version = "0.9.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e408f29489b5fd500fab51ff1484fc859bb655f32c671f307dcd733b72e8168c"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -2996,7 +3060,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -3024,7 +3088,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -3506,6 +3570,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,7 +3633,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4130,6 +4224,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,5 +47,6 @@ opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
 opentelemetry-appender-tracing = "0.30.1"
 
 [dev-dependencies]
+rstest = "0.26.1"
 mockall = "0.13.1"
 pretty_assertions = { version = "1.4.1", features = ["unstable"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@
 pub mod configuration;
 pub mod contracts;
 pub mod http;
+pub mod models;
 pub mod services;
+
 // #[cfg(feature = "testing")]
 // COVERAGE: disabled since the module is only compiled for testing purposes
 #[cfg_attr(coverage, coverage(off))]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,1 @@
+pub mod external_token;

--- a/src/models/external_token.rs
+++ b/src/models/external_token.rs
@@ -1,0 +1,61 @@
+#[cfg(test)]
+mod tests;
+
+use actix_web::dev::ServiceRequest;
+use actix_web::http::header::HeaderValue;
+use anyhow::{anyhow, bail};
+
+/// Represents an external JWT Token used to authorize the `ExternalIdentity` and issue an `InternalToken`
+#[derive(Clone)]
+pub struct ExternalToken {
+    pub token: String,
+}
+
+/// Allows `ExternalToken` to be converted to a String
+impl Into<String> for ExternalToken {
+    fn into(self) -> String {
+        self.token.clone()
+    }
+}
+
+/// Allows a String to be converted to an `ExternalToken`
+impl From<String> for ExternalToken {
+    fn from(token: String) -> Self {
+        ExternalToken { token }
+    }
+}
+impl TryFrom<&HeaderValue> for ExternalToken {
+    type Error = anyhow::Error;
+
+    #[allow(unreachable_code)] // False detect
+    fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
+        match value.to_str() {
+            Ok(string_value) => {
+                let tokens = string_value.split(" ").collect::<Vec<&str>>();
+
+                if tokens.len() != 2 {
+                    return Err(bail!("Invalid token format"));
+                }
+
+                if tokens[0] != "Bearer" {
+                    return Err(bail!("Invalid token format"));
+                }
+
+                Ok(ExternalToken::from(tokens[1].to_owned()))
+            }
+            Err(_) => bail!("Invalid token format"),
+        }
+    }
+}
+
+impl TryFrom<&ServiceRequest> for ExternalToken {
+    type Error = anyhow::Error;
+
+    fn try_from(request: &ServiceRequest) -> Result<Self, Self::Error> {
+        let header = request
+            .headers()
+            .get("Authorization")
+            .ok_or(anyhow!("Missing Authorization header"))?;
+        ExternalToken::try_from(header)
+    }
+}

--- a/src/models/external_token.rs
+++ b/src/models/external_token.rs
@@ -7,23 +7,24 @@ use anyhow::{anyhow, bail};
 
 /// Represents an external JWT Token used to authorize the `ExternalIdentity` and issue an `InternalToken`
 #[derive(Clone)]
-pub struct ExternalToken {
-    pub token: String,
-}
+pub struct ExternalToken(String);
 
 /// Allows `ExternalToken` to be converted to a String
 impl Into<String> for ExternalToken {
     fn into(self) -> String {
-        self.token.clone()
+        self.0.clone()
     }
 }
 
 /// Allows a String to be converted to an `ExternalToken`
 impl From<String> for ExternalToken {
     fn from(token: String) -> Self {
-        ExternalToken { token }
+        ExternalToken(token)
     }
 }
+
+/// Allows a `HeaderValue` to be converted to an `ExternalToken` if it follows the expected
+/// "Bearer <token>" format
 impl TryFrom<&HeaderValue> for ExternalToken {
     type Error = anyhow::Error;
 
@@ -48,6 +49,8 @@ impl TryFrom<&HeaderValue> for ExternalToken {
     }
 }
 
+/// Allows a `ServiceRequest` to be converted to an `ExternalToken` by extracting the
+/// "Authorization" header and parsing it as an `ExternalToken`
 impl TryFrom<&ServiceRequest> for ExternalToken {
     type Error = anyhow::Error;
 

--- a/src/models/external_token/tests.rs
+++ b/src/models/external_token/tests.rs
@@ -1,0 +1,23 @@
+use super::ExternalToken;
+use actix_web::http::header::HeaderValue;
+use rstest::rstest;
+
+#[rstest]
+fn test_parsing_valid_token() {
+    let header = HeaderValue::from_static("Bearer token");
+    let token = ExternalToken::try_from(&header).unwrap();
+    let string_token: String = token.into();
+    assert_eq!(string_token, "token".to_string());
+}
+
+#[rstest]
+#[case("token")]
+#[case("My token")]
+#[case("My suer cool token")]
+#[case("")]
+#[case("Bearer")]
+fn test_parsing_invalid_token(#[case] token: &str) {
+    let header = HeaderValue::from_str(token).unwrap();
+    let token = ExternalToken::try_from(&header);
+    assert_eq!(token.is_err_and(|e| e.to_string() == "Invalid token format"), true);
+}


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71
Also related to https://github.com/SneaksAndData/boxer-core/issues/70

## Scope

Implemented:
- Move external token to the `boxer-core`  package form `boxer-issuer` package. This is required to simplify the development process for the audited pipeline implementation.

## Checklist

- [x] GitHub issue exists for this change.
- [x] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.