### PR TITLE
Fix audit recorder type after testing

### DIFF
--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -7,7 +7,7 @@ mod tests;
 use super::audited_error::AuditedError;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;
 

--- a/src/http/middleware/audit/audit_recorder.rs
+++ b/src/http/middleware/audit/audit_recorder.rs
@@ -7,7 +7,7 @@ mod tests;
 use super::audited_error::AuditedError;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
+use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;
 
@@ -37,7 +37,9 @@ where
     Next: Service<ServiceRequest, Response = ServiceResponse<BodyType>, Error = actix_web::Error> + 'static,
     Next::Future: 'static,
     BodyType: 'static,
-    AES: for<'a> TryFrom<&'a ServiceResponse<BodyType>, Error = actix_web::Error> + AuditEventSource,
+    AES: TryFrom<ServiceResponse<BodyType>, Error = actix_web::Error>
+        + AuditEventSource
+        + Into<ServiceResponse<BodyType>>,
 {
     type Response = ServiceResponse<BodyType>;
     type Error = actix_web::Error;
@@ -53,9 +55,9 @@ where
 
             match result {
                 Ok(response) => {
-                    let audited: AES = AES::try_from(&response)?;
+                    let audited: AES = AES::try_from(response)?;
                     audit_writer.write(audited.audit_event());
-                    Ok(response)
+                    Ok(audited.into())
                 }
 
                 Err(error) => {

--- a/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
@@ -1,6 +1,6 @@
-use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
+use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;
@@ -28,7 +28,9 @@ where
     NextService: Service<ServiceRequest, Response = ServiceResponse<BodyType>, Error = actix_web::Error> + 'static,
     NextService::Future: 'static,
     BodyType: 'static,
-    AES: for<'a> TryFrom<&'a ServiceResponse<BodyType>, Error = actix_web::Error> + AuditEventSource,
+    AES: TryFrom<ServiceResponse<BodyType>, Error = actix_web::Error>
+        + AuditEventSource
+        + Into<ServiceResponse<BodyType>>,
 {
     type Response = ServiceResponse<BodyType>;
     type Error = actix_web::Error;

--- a/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
+++ b/src/http/middleware/audit/audit_recorder/audit_recorder_factory.rs
@@ -1,6 +1,6 @@
+use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use crate::http::middleware::audit::audit_recorder::AuditRecorder;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use futures_util::future::LocalBoxFuture;
 use std::sync::Arc;

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -7,7 +7,7 @@ use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use actix_web::body::BoxBody;
 use actix_web::dev::ServiceResponse;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::{App, Error, HttpMessage, HttpResponse, test, web};
+use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
 use anyhow::Result;
 use mockall::mock;
 use pretty_assertions::assert_matches;
@@ -148,10 +148,19 @@ mock! {
     }
 }
 
-impl<B> TryFrom<&ServiceResponse<B>> for MockAuditEventSource {
+mock! {
+
+    pub AuditWriter {}
+
+    impl AuditWriter for AuditWriter {
+        fn write(&self, event: AuditEvent);
+    }
+}
+
+impl<B> TryFrom<ServiceResponse<B>> for MockAuditEventSource {
     type Error = actix_web::Error;
 
-    fn try_from(_value: &ServiceResponse<B>) -> Result<Self, Self::Error> {
+    fn try_from(_value: ServiceResponse<B>) -> Result<Self, Self::Error> {
         let mut mock = MockAuditEventSource::new();
         mock.expect_audit_event()
             .returning(|| AuditEvent::Intermediate(ChainedAuditEvent::empty()));
@@ -159,11 +168,11 @@ impl<B> TryFrom<&ServiceResponse<B>> for MockAuditEventSource {
     }
 }
 
-mock! {
-
-    pub AuditWriter {}
-
-    impl AuditWriter for AuditWriter {
-        fn write(&self, event: AuditEvent);
+impl Into<ServiceResponse<BoxBody>> for MockAuditEventSource {
+    fn into(self) -> ServiceResponse<BoxBody> {
+        ServiceResponse::new(
+            test::TestRequest::get().uri("/token").to_http_request(),
+            HttpResponse::Ok().finish(),
+        )
     }
 }

--- a/src/http/middleware/audit/audit_recorder/tests.rs
+++ b/src/http/middleware/audit/audit_recorder/tests.rs
@@ -7,7 +7,7 @@ use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use actix_web::body::BoxBody;
 use actix_web::dev::ServiceResponse;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::{test, web, App, Error, HttpMessage, HttpResponse};
+use actix_web::{App, Error, HttpMessage, HttpResponse, test, web};
 use anyhow::Result;
 use mockall::mock;
 use pretty_assertions::assert_matches;


### PR DESCRIPTION
Part of #71
Also related to #70

This PR simplifies the audit recorder after unit testing. This changes type bounds of AuditEventSource type, removing lifetime specification.

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [x] Review requested on `latest` commit.