### PR TITLE
Fix incorrect ExternalToken impls

### DIFF
--- a/src/models/external_token.rs
+++ b/src/models/external_token.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod tests;
 
-use actix_web::dev::ServiceRequest;
+use crate::http::middleware::audit::external_token::token_with_id::TokenWithId;
 use actix_web::http::header::HeaderValue;
-use anyhow::{anyhow, bail};
+use anyhow::bail;
 
 /// Represents an external JWT Token used to authorize the `ExternalIdentity` and issue an `InternalToken`
 #[derive(Clone)]
@@ -25,11 +25,11 @@ impl From<String> for ExternalToken {
 
 /// Allows a `HeaderValue` to be converted to an `ExternalToken` if it follows the expected
 /// "Bearer <token>" format
-impl TryFrom<&HeaderValue> for ExternalToken {
+impl TryFrom<HeaderValue> for ExternalToken {
     type Error = anyhow::Error;
 
     #[allow(unreachable_code)] // False detect
-    fn try_from(value: &HeaderValue) -> Result<Self, Self::Error> {
+    fn try_from(value: HeaderValue) -> Result<Self, Self::Error> {
         match value.to_str() {
             Ok(string_value) => {
                 let tokens = string_value.split(" ").collect::<Vec<&str>>();
@@ -49,16 +49,9 @@ impl TryFrom<&HeaderValue> for ExternalToken {
     }
 }
 
-/// Allows a `ServiceRequest` to be converted to an `ExternalToken` by extracting the
-/// "Authorization" header and parsing it as an `ExternalToken`
-impl TryFrom<&ServiceRequest> for ExternalToken {
-    type Error = anyhow::Error;
-
-    fn try_from(request: &ServiceRequest) -> Result<Self, Self::Error> {
-        let header = request
-            .headers()
-            .get("Authorization")
-            .ok_or(anyhow!("Missing Authorization header"))?;
-        ExternalToken::try_from(header)
+impl TokenWithId for ExternalToken {
+    fn id(&self) -> String {
+        let token_hash = md5::compute(&self.0);
+        format!("md5:{:x}", token_hash)
     }
 }

--- a/src/models/external_token/tests.rs
+++ b/src/models/external_token/tests.rs
@@ -5,7 +5,7 @@ use rstest::rstest;
 #[rstest]
 fn test_parsing_valid_token() {
     let header = HeaderValue::from_static("Bearer token");
-    let token = ExternalToken::try_from(&header).unwrap();
+    let token = ExternalToken::try_from(header).unwrap();
     let string_token: String = token.into();
     assert_eq!(string_token, "token".to_string());
 }
@@ -18,6 +18,6 @@ fn test_parsing_valid_token() {
 #[case("Bearer")]
 fn test_parsing_invalid_token(#[case] token: &str) {
     let header = HeaderValue::from_str(token).unwrap();
-    let token = ExternalToken::try_from(&header);
+    let token = ExternalToken::try_from(header);
     assert_eq!(token.is_err_and(|e| e.to_string() == "Invalid token format"), true);
 }


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71
Also related to https://github.com/SneaksAndData/boxer-core/issues/70

## Scope

This PR removes the implementation of the `TryFrom<&ServiceRequest>` trait for `ExternalToken` and adds the `TokenWithId` implementation for `ExternalToken`

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.