### PR TITLE
Implement AuditWriter for LogAuditService

### DIFF
--- a/src/services/audit/log_audit_service.rs
+++ b/src/services/audit/log_audit_service.rs
@@ -1,11 +1,14 @@
-use crate::services::audit::AuditService;
+use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
+use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
 use crate::services::audit::events::resource_delete_audit_event::ResourceDeleteAuditEvent;
 use crate::services::audit::events::resource_modification_audit_event::{
     ModificationResult, ResourceModificationAuditEvent,
 };
 use crate::services::audit::events::token_validation_event::TokenValidationEvent;
+use crate::services::audit::AuditService;
 use anyhow::Result;
+use std::collections::HashSet;
 
 pub struct LogAuditService;
 
@@ -105,5 +108,41 @@ impl AuditService for LogAuditService {
             "Boxer token validation: {:?}/{:?}", event.token_type, event.token_id);
 
         Ok(())
+    }
+}
+
+impl AuditWriter for LogAuditService {
+    /// Writes an audit event as a structured log entry.
+    ///
+    /// Both intermediate and final events are normalized into a single payload
+    /// shape and emitted with `log_type = "audit"` so downstream log systems can
+    /// reliably filter and index audit records.
+
+    // COVERAGE: disabled since this should be tested in integration tests only
+    #[cfg_attr(coverage, coverage(off))]
+    fn write(&self, event: AuditEvent) {
+        let (payload, is_final) = match event {
+            AuditEvent::Final(e) => (e, true),
+            AuditEvent::Intermediate(e) => (e, false),
+        };
+
+        log::info!(
+            // Indicates the audit events for easier filtering in log aggregation systems
+            log_type = "audit",
+
+            // The event decomposition for structured logging
+            is_final = is_final,
+            action = payload.action,
+            actor = payload.actor,
+            resource = payload.resource,
+            decision:serde = payload.decision,
+            reason_policies:serde = payload.reason.clone().map_or(HashSet::new(), |r| r.policies),
+            reason_errors:serde = payload.reason.map(|r| r.errors).unwrap_or(HashSet::new()),
+            external_token_id = payload.external_token.or(None).map(|t| t.token_id),
+            internal_token_id = payload.internal_token.or(None).map(|t| t.token_id);
+
+            // The log message
+            "Boxer audit event recorded with decision: {:?}", payload.decision
+        );
     }
 }

--- a/src/services/audit/log_audit_service.rs
+++ b/src/services/audit/log_audit_service.rs
@@ -1,4 +1,5 @@
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
+use crate::services::audit::AuditService;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
 use crate::services::audit::events::resource_delete_audit_event::ResourceDeleteAuditEvent;
@@ -6,7 +7,6 @@ use crate::services::audit::events::resource_modification_audit_event::{
     ModificationResult, ResourceModificationAuditEvent,
 };
 use crate::services::audit::events::token_validation_event::TokenValidationEvent;
-use crate::services::audit::AuditService;
 use anyhow::Result;
 use std::collections::HashSet;
 


### PR DESCRIPTION
Part of #71
Also related to #70

## Scope

Implemented:
- Implemented `AuditWriter` interface for the `LogAuditService` struct.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.