### PR TITLE
Add 'static lifetime specifier to the AuditService trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,7 +2325,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand 0.9.4",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",

--- a/src/services/audit.rs
+++ b/src/services/audit.rs
@@ -9,7 +9,7 @@ use crate::services::audit::events::resource_modification_audit_event::ResourceM
 use crate::services::audit::events::token_validation_event::TokenValidationEvent;
 use anyhow::Result;
 
-pub trait AuditService: Send + Sync {
+pub trait AuditService: Send + Sync + 'static {
     fn record_authorization(&self, event: AuthorizationAuditEvent) -> Result<()>;
     fn record_resource_deletion(&self, event: ResourceDeleteAuditEvent) -> Result<()>;
     fn record_resource_modification(&self, event: ResourceModificationAuditEvent) -> Result<()>;


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71
Also related to https://github.com/SneaksAndData/boxer-core/issues/70

Required for integration tests

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.