### PR TITLE
Change the method `add_token_id`

### DIFF
--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -9,9 +9,9 @@ use crate::models::external_token::ExternalToken;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
-use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
+use actix_web::HttpMessage;
 
 /// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.
@@ -108,7 +108,7 @@ impl RequestWithTokenId for AuditedRequest {
     ///
     /// Panics if the audit event in extensions is not an `AuditEvent::Intermediate`,
     /// which would mean the audit chain is in an unexpected state.
-    fn add_token_id(self, token: &Self::Token) -> ServiceRequest {
+    fn add_token(self, token: Self::Token) -> ServiceRequest {
         let token_id = token.id();
 
         {
@@ -131,6 +131,8 @@ impl RequestWithTokenId for AuditedRequest {
                     audit_event
                 );
             }
+
+            binding.insert(token.clone());
         }
 
         // Return the updated value

--- a/src/http/middleware/audit/audited_request.rs
+++ b/src/http/middleware/audit/audited_request.rs
@@ -9,9 +9,9 @@ use crate::models::external_token::ExternalToken;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::HttpMessage;
 
 /// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.

--- a/src/http/middleware/extract_external_token.rs
+++ b/src/http/middleware/extract_external_token.rs
@@ -24,7 +24,7 @@ pub async fn extract_external_token<Request: RequestWithTokenId, Error: External
         Some(header_value) => {
             let token =
                 Request::Token::try_from(header_value).map_err(|e| Error::token_extraction_failed(&request, e))?;
-            next.call(Request::from(request).add_token_id(&token)).await
+            next.call(Request::from(request).add_token(token)).await
         }
     }
 }

--- a/src/http/middleware/extract_external_token/request_with_token_id.rs
+++ b/src/http/middleware/extract_external_token/request_with_token_id.rs
@@ -10,8 +10,9 @@ pub trait RequestWithTokenId: From<ServiceRequest> {
     /// Token type used to derive the external token identifier.
     type Token: TokenWithId;
 
-    /// Stores the provided token id in the request audit context and returns the updated request.
+    /// Stores the provided token in the request context and returns the updated request.
+    /// The method additionally enriches the audit event coming to the request with the token id.
     /// This method should be called to add the token id and convert the request to the appropriate
     /// type for downstream handlers and middleware.
-    fn add_token_id(self, token: &Self::Token) -> ServiceRequest;
+    fn add_token(self, token: Self::Token) -> ServiceRequest;
 }


### PR DESCRIPTION
Part of #71
Also related to #70

This PR renames the `add_token_id` to `add_token` and changes the semantics of the method.

Instead of injecting the token id into the requests extensions, now it injects **the token itself** and the token id.

This is required since the `extract_external_token` middleware is not intended to extract audit metadata, but **the metadata and the token itself** for further processing.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.