### PR TITLE
Implement internal request and external request

### DIFF
--- a/src/contracts/internal_token/encrypted_token.rs
+++ b/src/contracts/internal_token/encrypted_token.rs
@@ -2,6 +2,7 @@ use crate::http::middleware::extract_external_token::token_with_id::TokenWithId;
 use actix_web::http::header::HeaderValue;
 
 /// Wraps the raw encrypted token value extracted from request headers.
+#[derive(Clone)]
 pub struct EncryptedToken(String);
 
 impl TryFrom<HeaderValue> for EncryptedToken {

--- a/src/http/middleware/audit.rs
+++ b/src/http/middleware/audit.rs
@@ -1,8 +1,9 @@
 pub mod audit_recorder;
 pub mod audited_error;
-pub mod audited_request;
 pub mod audited_response;
 pub mod begin_audit_chain;
+pub mod external_request;
+pub mod internal_request;
 
 pub mod audit_scope;
 #[cfg(test)]

--- a/src/http/middleware/audit/audit_scope.rs
+++ b/src/http/middleware/audit/audit_scope.rs
@@ -5,9 +5,9 @@ use crate::http::middleware::audit::audited_response::AuditedResponse;
 use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
 use crate::http::middleware::audit::external_request::ExternalRequest;
 use crate::http::middleware::extract_external_token::extract_external_token;
+use actix_web::Scope;
 use actix_web::dev::HttpServiceFactory;
 use actix_web::middleware::from_fn;
-use actix_web::Scope;
 use std::sync::Arc;
 
 /// Extension trait for attaching the complete audit middleware chain to an Actix [`Scope`].

--- a/src/http/middleware/audit/audit_scope.rs
+++ b/src/http/middleware/audit/audit_scope.rs
@@ -1,13 +1,13 @@
 use crate::http::middleware::audit::audit_recorder::audit_recorder_factory::AuditRecorderFactory;
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
 use crate::http::middleware::audit::audited_error::AuditedError;
-use crate::http::middleware::audit::audited_request::AuditedRequest;
 use crate::http::middleware::audit::audited_response::AuditedResponse;
 use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
+use crate::http::middleware::audit::external_request::ExternalRequest;
 use crate::http::middleware::extract_external_token::extract_external_token;
-use actix_web::Scope;
 use actix_web::dev::HttpServiceFactory;
 use actix_web::middleware::from_fn;
+use actix_web::Scope;
 use std::sync::Arc;
 
 /// Extension trait for attaching the complete audit middleware chain to an Actix [`Scope`].
@@ -26,8 +26,8 @@ pub trait AuditScope {
 
 impl AuditScope for Scope {
     fn with_initial_audit_scope(self, writer: Arc<dyn AuditWriter>) -> impl HttpServiceFactory {
-        self.wrap(from_fn(extract_external_token::<AuditedRequest, AuditedError>))
+        self.wrap(from_fn(extract_external_token::<ExternalRequest, AuditedError>))
             .wrap(AuditRecorderFactory::<AuditedResponse<_>>::new(writer))
-            .wrap(from_fn(begin_audit_chain::<AuditedRequest>))
+            .wrap(from_fn(begin_audit_chain::<ExternalRequest>))
     }
 }

--- a/src/http/middleware/audit/begin_audit_chain/tests.rs
+++ b/src/http/middleware/audit/begin_audit_chain/tests.rs
@@ -2,7 +2,7 @@ use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use actix_web::dev::ServiceRequest;
 use actix_web::middleware::from_fn;
-use actix_web::{test, web, App, HttpRequest, HttpResponse};
+use actix_web::{App, HttpRequest, HttpResponse, test, web};
 use mockall::mock;
 
 #[actix_web::test]

--- a/src/http/middleware/audit/begin_audit_chain/tests.rs
+++ b/src/http/middleware/audit/begin_audit_chain/tests.rs
@@ -2,7 +2,7 @@ use crate::http::middleware::audit::begin_audit_chain::begin_audit_chain;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use actix_web::dev::ServiceRequest;
 use actix_web::middleware::from_fn;
-use actix_web::{App, HttpRequest, HttpResponse, test, web};
+use actix_web::{test, web, App, HttpRequest, HttpResponse};
 use mockall::mock;
 
 #[actix_web::test]
@@ -40,8 +40,6 @@ mock! {
 
     impl TryCreateAuditContext for AuditContext {
         fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error>;
-
-        fn is_final(&self) -> bool { false }
     }
 
     impl Into<ServiceRequest> for AuditContext {

--- a/src/http/middleware/audit/begin_audit_chain/try_create_audit_context.rs
+++ b/src/http/middleware/audit/begin_audit_chain/try_create_audit_context.rs
@@ -9,6 +9,4 @@ pub trait TryCreateAuditContext: Into<ServiceRequest> {
     fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error>
     where
         Self: Sized;
-
-    fn is_final(&self) -> bool;
 }

--- a/src/http/middleware/audit/external_request.rs
+++ b/src/http/middleware/audit/external_request.rs
@@ -1,0 +1,134 @@
+#[cfg(test)]
+mod tests;
+
+use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+use crate::http::middleware::extract_external_token::token_with_id::TokenWithId;
+use crate::http::middleware::request_with_token_id::RequestWithTokenId;
+use crate::models::external_token::ExternalToken;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
+use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use actix_web::dev::ServiceRequest;
+use actix_web::error::ErrorInternalServerError;
+use actix_web::HttpMessage;
+
+/// [`ExternalRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
+/// processed by the `begin_audit_chain` middleware and has an audit context initialized.
+/// This struct is used to ensure that the audit context is properly initialized and to prevent
+/// multiple initializations of the audit context for the same request.
+#[derive(Debug)]
+pub struct ExternalRequest(ServiceRequest);
+
+/// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
+/// a `ServiceRequest` when passing it to the next middleware or handler in the chain.
+impl Into<ServiceRequest> for ExternalRequest {
+    fn into(self) -> ServiceRequest {
+        self.0
+    }
+}
+
+/// The `TryCreateAuditContext` trait is implemented for `AuditedRequest` to define the logic for
+/// creating an audit context from a `ServiceRequest`. The implementation checks if the request
+/// already contains an `AuditEvent` in its extensions, which would indicate that an audit context
+/// has already been initialized.
+impl TryCreateAuditContext for ExternalRequest {
+    fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error> {
+        if request.extensions().get::<AuditEvent>().is_some() {
+            return Err(ErrorInternalServerError(
+                "Failed to create audited request: audit chain already exists in request extensions",
+            ));
+        }
+        request
+            .extensions_mut()
+            .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
+        Ok(ExternalRequest(request))
+    }
+}
+
+impl AuditEventSource for ExternalRequest {
+    /// Returns the current [`AuditEvent`] stored in the request extensions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the request does not contain an `AuditEvent` extension.
+    /// This should never happen for a properly constructed [`ExternalRequest`],
+    /// since `try_create_audit_context` always inserts an event on creation.
+    fn audit_event(&self) -> AuditEvent {
+        self.0
+            .extensions()
+            .get::<AuditEvent>()
+            .cloned()
+            .expect("Audited event not exists in request extensions")
+    }
+}
+
+impl From<ServiceRequest> for ExternalRequest {
+    /// Wraps a [`ServiceRequest`] into an [`ExternalRequest`], asserting that an audit context
+    /// is already present in request extensions.
+    ///
+    /// This is the counterpart to [`Into<ServiceRequest>`] and is used by the external token
+    /// middleware to re-wrap the request after extracting the token, preserving the existing
+    /// audit context.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the request does not contain an [`AuditEvent`] extension.
+
+    fn from(value: ServiceRequest) -> Self {
+        value
+            .extensions()
+            .get::<AuditEvent>()
+            .cloned()
+            .expect("Audited event not exists in request extensions");
+        ExternalRequest(value)
+    }
+}
+
+impl RequestWithTokenId for ExternalRequest {
+    type Token = ExternalToken;
+
+    /// Stores the external token identifier in the request's audit context and returns
+    /// the underlying [`ServiceRequest`].
+    ///
+    /// The token id is derived from the provided [`ExternalToken`] and written into the
+    /// intermediate [`ChainedAuditEvent`] held in request extensions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the request extensions already contain an external token audit event,
+    /// indicating a duplicate token id assignment.
+    ///
+    /// Panics if the audit event in extensions is not an `AuditEvent::Intermediate`,
+    /// which would mean the audit chain is in an unexpected state.
+    fn add_token(self, token: Self::Token) -> ServiceRequest {
+        let token_id = token.id();
+
+        {
+            let mut binding = self.0.extensions_mut();
+            let audit_event = binding.get_mut::<AuditEvent>();
+
+            // Mutate the audit event if the audit event complains the expected structure
+            if let Some(AuditEvent::Intermediate(chained_audit_event)) = audit_event {
+                if chained_audit_event.external_token.is_some() {
+                    panic!(
+                        "External token audit event already exists in request extensions: {:?}",
+                        chained_audit_event.external_token
+                    );
+                }
+                chained_audit_event.external_token = Some(TokenAuditEvent::external().with_token_id(&token_id))
+            } else {
+                // Otherwise, stop processing immediately
+                panic!(
+                    "Expected Intermediate Audit event to exist in request extension, but got {:?}",
+                    audit_event
+                );
+            }
+
+            binding.insert(token.clone());
+        }
+
+        // Return the updated value
+        self.0
+    }
+}

--- a/src/http/middleware/audit/external_request.rs
+++ b/src/http/middleware/audit/external_request.rs
@@ -9,9 +9,9 @@ use crate::models::external_token::ExternalToken;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::HttpMessage;
 
 /// [`ExternalRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.

--- a/src/http/middleware/audit/external_request/tests.rs
+++ b/src/http/middleware/audit/external_request/tests.rs
@@ -1,9 +1,9 @@
-use crate::http::middleware::audit::audited_request::AuditedRequest;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::http::middleware::audit::external_request::ExternalRequest;
 use crate::services::audit::chained::audit_event::AuditEvent;
-use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::test::TestRequest;
+use actix_web::HttpMessage;
 use pretty_assertions::assert_matches;
 
 #[test]
@@ -12,7 +12,7 @@ fn test_audit_event_initialization() {
     let request = TestRequest::get().uri("/any-route").to_srv_request();
 
     // Act
-    let result = AuditedRequest::try_create_audit_context(request);
+    let result = ExternalRequest::try_create_audit_context(request);
 
     // Assert
     assert_matches!(result, Ok(_));
@@ -27,8 +27,8 @@ fn test_audit_event_double_initialization() {
     let request = TestRequest::get().uri("/any-route").to_srv_request();
 
     // Act
-    let request: ServiceRequest = AuditedRequest::try_create_audit_context(request).unwrap().into();
-    let result = AuditedRequest::try_create_audit_context(request);
+    let request: ServiceRequest = ExternalRequest::try_create_audit_context(request).unwrap().into();
+    let result = ExternalRequest::try_create_audit_context(request);
 
     // Assert
     assert_matches!(result, Err(_));

--- a/src/http/middleware/audit/external_request/tests.rs
+++ b/src/http/middleware/audit/external_request/tests.rs
@@ -1,9 +1,9 @@
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::http::middleware::audit::external_request::ExternalRequest;
 use crate::services::audit::chained::audit_event::AuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::test::TestRequest;
-use actix_web::HttpMessage;
 use pretty_assertions::assert_matches;
 
 #[test]

--- a/src/http/middleware/audit/internal_request.rs
+++ b/src/http/middleware/audit/internal_request.rs
@@ -2,27 +2,27 @@
 mod tests;
 
 use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::contracts::internal_token::encrypted_token::EncryptedToken;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::extract_external_token::token_with_id::TokenWithId;
 use crate::http::middleware::request_with_token_id::RequestWithTokenId;
-use crate::models::external_token::ExternalToken;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
-use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
+use actix_web::HttpMessage;
 
-/// [`AuditedRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
+/// [`InternalRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.
 /// This struct is used to ensure that the audit context is properly initialized and to prevent
 /// multiple initializations of the audit context for the same request.
 #[derive(Debug)]
-pub struct AuditedRequest(ServiceRequest);
+pub struct InternalRequest(ServiceRequest);
 
 /// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
 /// a `ServiceRequest` when passing it to the next middleware or handler in the chain.
-impl Into<ServiceRequest> for AuditedRequest {
+impl Into<ServiceRequest> for InternalRequest {
     fn into(self) -> ServiceRequest {
         self.0
     }
@@ -32,7 +32,7 @@ impl Into<ServiceRequest> for AuditedRequest {
 /// creating an audit context from a `ServiceRequest`. The implementation checks if the request
 /// already contains an `AuditEvent` in its extensions, which would indicate that an audit context
 /// has already been initialized.
-impl TryCreateAuditContext for AuditedRequest {
+impl TryCreateAuditContext for InternalRequest {
     fn try_create_audit_context(request: ServiceRequest) -> Result<Self, actix_web::Error> {
         if request.extensions().get::<AuditEvent>().is_some() {
             return Err(ErrorInternalServerError(
@@ -42,24 +42,17 @@ impl TryCreateAuditContext for AuditedRequest {
         request
             .extensions_mut()
             .insert(AuditEvent::Intermediate(ChainedAuditEvent::empty()));
-        Ok(AuditedRequest(request))
-    }
-
-    fn is_final(&self) -> bool {
-        match self.0.extensions().get::<AuditEvent>() {
-            None => panic!("Audit event should exist in request extensions"),
-            Some(event) => matches!(event, AuditEvent::Final(_)),
-        }
+        Ok(InternalRequest(request))
     }
 }
 
-impl AuditEventSource for AuditedRequest {
+impl AuditEventSource for InternalRequest {
     /// Returns the current [`AuditEvent`] stored in the request extensions.
     ///
     /// # Panics
     ///
     /// Panics if the request does not contain an `AuditEvent` extension.
-    /// This should never happen for a properly constructed [`AuditedRequest`],
+    /// This should never happen for a properly constructed [`InternalRequest`],
     /// since `try_create_audit_context` always inserts an event on creation.
     fn audit_event(&self) -> AuditEvent {
         self.0
@@ -70,8 +63,8 @@ impl AuditEventSource for AuditedRequest {
     }
 }
 
-impl From<ServiceRequest> for AuditedRequest {
-    /// Wraps a [`ServiceRequest`] into an [`AuditedRequest`], asserting that an audit context
+impl From<ServiceRequest> for InternalRequest {
+    /// Wraps a [`ServiceRequest`] into an [`InternalRequest`], asserting that an audit context
     /// is already present in request extensions.
     ///
     /// This is the counterpart to [`Into<ServiceRequest>`] and is used by the external token
@@ -88,12 +81,12 @@ impl From<ServiceRequest> for AuditedRequest {
             .get::<AuditEvent>()
             .cloned()
             .expect("Audited event not exists in request extensions");
-        AuditedRequest(value)
+        InternalRequest(value)
     }
 }
 
-impl RequestWithTokenId for AuditedRequest {
-    type Token = ExternalToken;
+impl RequestWithTokenId for InternalRequest {
+    type Token = EncryptedToken;
 
     /// Stores the external token identifier in the request's audit context and returns
     /// the underlying [`ServiceRequest`].
@@ -117,13 +110,13 @@ impl RequestWithTokenId for AuditedRequest {
 
             // Mutate the audit event if the audit event complains the expected structure
             if let Some(AuditEvent::Intermediate(chained_audit_event)) = audit_event {
-                if chained_audit_event.external_token.is_some() {
+                if chained_audit_event.internal_token.is_some() {
                     panic!(
                         "External token audit event already exists in request extensions: {:?}",
-                        chained_audit_event.external_token
+                        chained_audit_event.internal_token
                     );
                 }
-                chained_audit_event.external_token = Some(TokenAuditEvent::external().with_token_id(&token_id))
+                chained_audit_event.internal_token = Some(TokenAuditEvent::external().with_token_id(&token_id))
             } else {
                 // Otherwise, stop processing immediately
                 panic!(

--- a/src/http/middleware/audit/internal_request.rs
+++ b/src/http/middleware/audit/internal_request.rs
@@ -9,9 +9,9 @@ use crate::http::middleware::request_with_token_id::RequestWithTokenId;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::HttpMessage;
 
 /// [`InternalRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.

--- a/src/http/middleware/audit/internal_request/tests.rs
+++ b/src/http/middleware/audit/internal_request/tests.rs
@@ -1,0 +1,42 @@
+use super::InternalRequest;
+use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::services::audit::chained::audit_event::AuditEvent;
+use actix_web::dev::ServiceRequest;
+use actix_web::test::TestRequest;
+use actix_web::HttpMessage;
+use pretty_assertions::assert_matches;
+
+#[test]
+fn test_audit_event_initialization() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+
+    // Act
+    let result = InternalRequest::try_create_audit_context(request);
+
+    // Assert
+    assert_matches!(result, Ok(_));
+    let service_request: ServiceRequest = result.unwrap().into();
+    let audit_event = service_request.extensions().get::<AuditEvent>().cloned();
+    assert_eq!(audit_event.is_some(), true);
+}
+
+#[test]
+fn test_audit_event_double_initialization() {
+    // Arrange
+    let request = TestRequest::get().uri("/any-route").to_srv_request();
+
+    // Act
+    let request: ServiceRequest = InternalRequest::try_create_audit_context(request).unwrap().into();
+    let result = InternalRequest::try_create_audit_context(request);
+
+    // Assert
+    assert_matches!(result, Err(_));
+    assert_eq!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Failed to create audited request:"),
+        true
+    );
+}

--- a/src/http/middleware/audit/internal_request/tests.rs
+++ b/src/http/middleware/audit/internal_request/tests.rs
@@ -1,9 +1,9 @@
 use super::InternalRequest;
 use crate::http::middleware::audit::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
 use crate::services::audit::chained::audit_event::AuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::test::TestRequest;
-use actix_web::HttpMessage;
 use pretty_assertions::assert_matches;
 
 #[test]

--- a/src/http/middleware/request_with_token_id.rs
+++ b/src/http/middleware/request_with_token_id.rs
@@ -8,7 +8,7 @@ use actix_web::dev::ServiceRequest;
 /// (for example, duplicate token identifiers).
 pub trait RequestWithTokenId: From<ServiceRequest> {
     /// Token type used to derive the external token identifier.
-    type Token: TokenWithId;
+    type Token: TokenWithId + Clone;
 
     /// Stores the provided token in the request context and returns the updated request.
     /// The method additionally enriches the audit event coming to the request with the token id.


### PR DESCRIPTION
Part of SneaksAndData/boxer-core#71
Also related to SneaksAndData/boxer-core#71

For the new middleware, the InternalRequest struct is implemented. The old `AuditedRequest` is renamed to `ExternalRequest` to make the purpose of the class more explicit.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.