### PR TITLE
Add token decrypt middleware

### DIFF
--- a/src/http/middleware.rs
+++ b/src/http/middleware.rs
@@ -8,9 +8,10 @@ use request_with_token_id::RequestWithTokenId;
 
 pub mod audit;
 pub mod extract_external_token;
-pub mod extract_internal_token;
+// pub mod extract_internal_token;
 pub mod logging;
 pub mod request_with_token_id;
+mod token_decryptor_middleware;
 pub mod tracer;
 
 async fn extract_token_from_header<TokenType, Request, Error>(

--- a/src/http/middleware.rs
+++ b/src/http/middleware.rs
@@ -8,7 +8,7 @@ use request_with_token_id::RequestWithTokenId;
 
 pub mod audit;
 pub mod extract_external_token;
-// pub mod extract_internal_token;
+pub mod extract_internal_token;
 pub mod logging;
 pub mod request_with_token_id;
 mod token_decryptor_middleware;

--- a/src/http/middleware.rs
+++ b/src/http/middleware.rs
@@ -11,7 +11,7 @@ pub mod extract_external_token;
 pub mod extract_internal_token;
 pub mod logging;
 pub mod request_with_token_id;
-mod token_decryptor_middleware;
+pub mod token_decryptor_middleware;
 pub mod tracer;
 
 async fn extract_token_from_header<TokenType, Request, Error>(

--- a/src/http/middleware/audit/audited_error.rs
+++ b/src/http/middleware/audit/audited_error.rs
@@ -22,6 +22,15 @@ pub struct AuditedError {
 impl AuditedError {
     /// Wraps a given `ResponseError` into an `AuditedError`, extracting the associated
     /// `AuditEvent` from the error's response extensions.
+    pub fn new(event: AuditEvent, cause: impl Error + 'static) -> AuditedError {
+        AuditedError {
+            event,
+            cause: Box::new(InternalError::new(cause, StatusCode::INTERNAL_SERVER_ERROR)),
+        }
+    }
+
+    /// Wraps a given `ResponseError` into an `AuditedError`, extracting the associated
+    /// `AuditEvent` from the error's response extensions.
     pub fn wrap(cause: impl ResponseError + 'static) -> AuditedError {
         let event = cause
             .error_response()

--- a/src/http/middleware/token_decryptor_middleware.rs
+++ b/src/http/middleware/token_decryptor_middleware.rs
@@ -1,0 +1,51 @@
+mod decryptor;
+mod request_with_token;
+mod token_decryptor_middleware_factory;
+
+use crate::http::middleware::audit::audited_error::AuditedError;
+use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
+use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
+use actix_web::error::ErrorBadRequest;
+use futures_util::future::LocalBoxFuture;
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Actix middleware that decrypts the token from the request and attaches claims.
+pub struct TokenDecryptorMiddleware<Next, D, R> {
+    decryptor: Arc<D>,
+    next: Rc<Next>,
+    phantom_data: PhantomData<R>,
+}
+
+impl<Next, Body, D, R> Service<ServiceRequest> for TokenDecryptorMiddleware<Next, D, R>
+where
+    Next: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = AuditedError> + 'static,
+    Next::Future: 'static,
+    Body: 'static,
+    D: Decryptor + 'static,
+    R: RequestWithToken + 'static,
+{
+    type Response = ServiceResponse<Body>;
+    type Error = AuditedError;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    forward_ready!(next);
+
+    /// Decrypts the token in the request, injects the claims, and forwards it downstream.
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let decryptor = self.decryptor.clone();
+        let next = self.next.clone();
+        let future = async move {
+            let mut request_with_token = R::try_from(req)?;
+            let encrypted_token = request_with_token.token();
+            let claims = decryptor
+                .decrypt(&encrypted_token)
+                .map_err(ErrorBadRequest)
+                .map_err(|e| AuditedError::new(request_with_token.audit_event(), e))?;
+            next.call(request_with_token.set_claims(claims)).await
+        };
+        Box::pin(future)
+    }
+}

--- a/src/http/middleware/token_decryptor_middleware.rs
+++ b/src/http/middleware/token_decryptor_middleware.rs
@@ -1,6 +1,6 @@
-mod decryptor;
-mod request_with_token;
-mod token_decryptor_middleware_factory;
+pub mod decryptor;
+pub mod request_with_token;
+pub mod token_decryptor_middleware_factory;
 
 use crate::http::middleware::audit::audited_error::AuditedError;
 use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;

--- a/src/http/middleware/token_decryptor_middleware/decryptor.rs
+++ b/src/http/middleware/token_decryptor_middleware/decryptor.rs
@@ -1,0 +1,8 @@
+use crate::contracts::dynamic_claims_collection::DynamicClaimsCollection;
+use crate::contracts::internal_token::encrypted_token::EncryptedToken;
+
+/// Decrypts encrypted internal tokens into a claims collection.
+pub trait Decryptor {
+    /// Decrypts the provided token and returns extracted dynamic claims.
+    fn decrypt(&self, token: &EncryptedToken) -> Result<DynamicClaimsCollection, anyhow::Error>;
+}

--- a/src/http/middleware/token_decryptor_middleware/request_with_token.rs
+++ b/src/http/middleware/token_decryptor_middleware/request_with_token.rs
@@ -1,0 +1,14 @@
+use crate::contracts::dynamic_claims_collection::DynamicClaimsCollection;
+use crate::contracts::internal_token::encrypted_token::EncryptedToken;
+use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
+use crate::http::middleware::audit::audited_error::AuditedError;
+use actix_web::dev::ServiceRequest;
+
+/// Abstraction over request types that carry an encrypted internal token.
+pub trait RequestWithToken: TryFrom<ServiceRequest, Error = AuditedError> + AuditEventSource {
+    /// Returns the encrypted token extracted from the request.
+    fn token(&self) -> EncryptedToken;
+
+    /// Stores decrypted claims in the request context and returns the updated request.
+    fn set_claims(&mut self, claims: DynamicClaimsCollection) -> ServiceRequest;
+}

--- a/src/http/middleware/token_decryptor_middleware/token_decryptor_middleware_factory.rs
+++ b/src/http/middleware/token_decryptor_middleware/token_decryptor_middleware_factory.rs
@@ -1,0 +1,49 @@
+use crate::http::middleware::audit::audited_error::AuditedError;
+use crate::http::middleware::token_decryptor_middleware::TokenDecryptorMiddleware;
+use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
+use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
+use futures_util::future::{Ready, ready};
+use std::marker::PhantomData;
+use std::rc::Rc;
+use std::sync::Arc;
+
+/// Factory that builds the [`TokenDecryptorMiddleware`]
+pub struct TokenDecryptorMiddlewareFactory<D, R> {
+    decryptor: Arc<D>,
+    phantom_data: PhantomData<R>,
+}
+
+impl<D, R> TokenDecryptorMiddlewareFactory<D, R> {
+    /// Creates a new decrypt-token middleware factory from the provided decryptor.
+    pub fn new(decryptor: Arc<D>) -> Self {
+        Self {
+            decryptor,
+            phantom_data: PhantomData,
+        }
+    }
+}
+
+impl<Next, Body, D, R> Transform<Next, ServiceRequest> for TokenDecryptorMiddlewareFactory<D, R>
+where
+    Next: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = AuditedError> + 'static,
+    Next::Future: 'static,
+    Body: 'static,
+    R: RequestWithToken + 'static,
+    D: Decryptor + 'static,
+{
+    type Response = ServiceResponse<Body>;
+    type Error = AuditedError;
+    type Transform = TokenDecryptorMiddleware<Next, D, R>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    /// Wraps the next service in a decrypt-token middleware instance.
+    fn new_transform(&self, next: Next) -> Self::Future {
+        ready(Ok(TokenDecryptorMiddleware {
+            decryptor: self.decryptor.clone(),
+            next: Rc::new(next),
+            phantom_data: PhantomData,
+        }))
+    }
+}


### PR DESCRIPTION
Part of #71
Also related to #71

This adds the middleware which should decrypt the incoming JWT for further processing.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.