### PR TITLE
Move the token decryption service from boxer-validator repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +440,7 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "assert_matches",
  "async-trait",
  "cedar-policy",
  "collection_macros",
@@ -451,6 +458,7 @@ dependencies = [
  "mockall",
  "opentelemetry",
  "opentelemetry-appender-log",
+ "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pretty_assertions",
@@ -2258,6 +2266,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68f63eca5fad47e570e00e893094fc17be959c80c79a7d6ec1abdd5ae6ffc16"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "opentelemetry-http"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3255,6 +3275,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3557,6 +3586,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3816,6 +3854,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,12 +286,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,9 +434,9 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "anyhow",
- "assert_matches",
  "async-trait",
  "cedar-policy",
+ "collection_macros",
  "duration-string",
  "env_filter",
  "futures",
@@ -457,7 +451,6 @@ dependencies = [
  "mockall",
  "opentelemetry",
  "opentelemetry-appender-log",
- "opentelemetry-appender-tracing",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "pretty_assertions",
@@ -625,6 +618,12 @@ dependencies = [
  "serde",
  "windows-link",
 ]
+
+[[package]]
+name = "collection_macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b180e6a75e306052a61658f832b4fc565a6e5a204da05f0fe7f50a31fb827a"
 
 [[package]]
 name = "concurrent-queue"
@@ -2259,18 +2258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-appender-tracing"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68f63eca5fad47e570e00e893094fc17be959c80c79a7d6ec1abdd5ae6ffc16"
-dependencies = [
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "opentelemetry-http"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3268,15 +3255,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sharded-slab"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3579,15 +3557,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,17 +3816,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ uuid = { version = "1.17.0", features = ["v4"] }
 tokio = { version = "1", features = ["full"] }
 serde_norway = "0.9"
 schemars = "0.8.6"
+assert_matches = "1.5.0"
 test-context = "0.4.1"
 actix-web = "4.11.0"
 duration-string = { version = "0.5.2", features = ["serde"] }
@@ -43,6 +44,7 @@ opentelemetry = "0.30.0"
 opentelemetry-appender-log = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
+opentelemetry-appender-tracing = "0.30.1"
 collection_macros = "0.2.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ uuid = { version = "1.17.0", features = ["v4"] }
 tokio = { version = "1", features = ["full"] }
 serde_norway = "0.9"
 schemars = "0.8.6"
-assert_matches = "1.5.0"
 test-context = "0.4.1"
 actix-web = "4.11.0"
 duration-string = { version = "0.5.2", features = ["serde"] }
@@ -44,7 +43,7 @@ opentelemetry = "0.30.0"
 opentelemetry-appender-log = "0.30.0"
 opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace", "metrics", "logs"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
-opentelemetry-appender-tracing = "0.30.1"
+collection_macros = "0.2.0"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/contracts/internal_token/encrypted_token.rs
+++ b/src/contracts/internal_token/encrypted_token.rs
@@ -23,3 +23,10 @@ impl TokenWithId for EncryptedToken {
         format!("md5:{:x}", token_hash)
     }
 }
+
+impl Into<String> for EncryptedToken {
+    /// Returns the underlying raw encrypted token from the [`EncryptedToken`] instance.
+    fn into(self) -> String {
+        self.0
+    }
+}

--- a/src/http/middleware/token_decryptor_middleware.rs
+++ b/src/http/middleware/token_decryptor_middleware.rs
@@ -41,7 +41,7 @@ where
             let mut request_with_token = R::try_from(req)?;
             let encrypted_token = request_with_token.token();
             let claims = decryptor
-                .decrypt(&encrypted_token)
+                .decrypt(encrypted_token)
                 .map_err(ErrorBadRequest)
                 .map_err(|e| AuditedError::new(request_with_token.audit_event(), e))?;
             next.call(request_with_token.set_claims(claims)).await

--- a/src/http/middleware/token_decryptor_middleware/decryptor.rs
+++ b/src/http/middleware/token_decryptor_middleware/decryptor.rs
@@ -4,5 +4,5 @@ use crate::contracts::internal_token::encrypted_token::EncryptedToken;
 /// Decrypts encrypted internal tokens into a claims collection.
 pub trait Decryptor {
     /// Decrypts the provided token and returns extracted dynamic claims.
-    fn decrypt(&self, token: &EncryptedToken) -> Result<DynamicClaimsCollection, anyhow::Error>;
+    fn decrypt(&self, token: EncryptedToken) -> Result<DynamicClaimsCollection, anyhow::Error>;
 }

--- a/src/services.rs
+++ b/src/services.rs
@@ -3,3 +3,4 @@ pub mod backends;
 pub mod base;
 pub mod observability;
 pub mod service_provider;
+pub mod token_decryption_service;

--- a/src/services/token_decryption_service.rs
+++ b/src/services/token_decryption_service.rs
@@ -1,0 +1,63 @@
+mod encryption_keys;
+mod token_settings;
+
+use crate::contracts::dynamic_claims_collection::DynamicClaimsCollection;
+use crate::contracts::internal_token::encrypted_token::EncryptedToken;
+use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
+use crate::services::token_decryption_service::encryption_keys::EncryptionKeys;
+use crate::services::token_decryption_service::token_settings::TokenValidationSettings;
+use anyhow::{anyhow, Result};
+use collection_macros::hashset;
+use josekit::jwe::Dir;
+use josekit::jwt;
+use serde_json::Value;
+use std::collections::HashSet;
+
+pub struct TokenDecryptionService {
+    pub keys: EncryptionKeys,
+    pub valid_issuers: HashSet<String>,
+    pub valid_audiences: HashSet<String>,
+}
+
+impl TokenDecryptionService {
+    pub fn new(keys: EncryptionKeys, token_settings: TokenValidationSettings) -> Self {
+        TokenDecryptionService {
+            keys,
+            valid_issuers: hashset! {token_settings.issuer},
+            valid_audiences: hashset![token_settings.audience],
+        }
+    }
+}
+
+impl Decryptor for TokenDecryptionService {
+    fn decrypt(&self, encrypted_token: EncryptedToken) -> Result<DynamicClaimsCollection> {
+        let raw: String = encrypted_token.into();
+        let header = jwt::decode_header(&raw).map_err(anyhow::Error::from)?;
+        let key_id = header
+            .claim("kid")
+            .and_then(Value::as_str)
+            .ok_or(anyhow::anyhow!("No 'kid' in token header"))?
+            .to_string();
+
+        let key = self
+            .keys
+            .get(&key_id)
+            .ok_or(anyhow!("No key found for kid: {}", key_id))
+            .map_err(anyhow::Error::from)?;
+
+        let decrypter = Dir.decrypter_from_bytes(key).map_err(anyhow::Error::from)?;
+        let (payload, header) = jwt::decode_with_decrypter(&raw, &decrypter)?;
+
+        let audiences = header.audience().ok_or(anyhow::anyhow!("No audience"))?;
+        if !audiences.iter().any(|a| self.valid_audiences.contains(*a)) {
+            return Err(anyhow::anyhow!("No valid audience"));
+        }
+
+        let issuer = header.issuer().ok_or(anyhow::anyhow!("No issuer"))?;
+        if !self.valid_issuers.contains(issuer) {
+            return Err(anyhow::anyhow!("Invalid issuer"));
+        }
+
+        Ok(payload)
+    }
+}

--- a/src/services/token_decryption_service.rs
+++ b/src/services/token_decryption_service.rs
@@ -6,7 +6,7 @@ use crate::contracts::internal_token::encrypted_token::EncryptedToken;
 use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
 use crate::services::token_decryption_service::encryption_keys::EncryptionKeys;
 use crate::services::token_decryption_service::token_settings::TokenValidationSettings;
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use collection_macros::hashset;
 use josekit::jwe::Dir;
 use josekit::jwt;

--- a/src/services/token_decryption_service/encryption_keys.rs
+++ b/src/services/token_decryption_service/encryption_keys.rs
@@ -1,0 +1,13 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+/// Configuration settings that contains the encryption keys used by Boxer validator app.
+#[derive(Debug, Deserialize)]
+pub struct EncryptionKeys(HashMap<String, String>);
+
+impl EncryptionKeys {
+    /// Returns the encryption key by key id
+    pub fn get(&self, key_id: &str) -> Option<&String> {
+        self.0.get(key_id)
+    }
+}

--- a/src/services/token_decryption_service/token_settings.rs
+++ b/src/services/token_decryption_service/token_settings.rs
@@ -1,0 +1,13 @@
+use serde::Deserialize;
+
+/// Represents the token validation settings used by boxer validator code
+#[derive(Debug, Deserialize)]
+pub struct TokenValidationSettings {
+    pub audience: String,
+    pub issuer: String,
+
+    /// We use JSON-encoded string for signature settings since the validator must support multiple
+    /// signatures for seamless key rotation. Unfortunately, the config-rs crate does not support
+    /// deserializing directly into a Vec or HashMap from environment variables.
+    pub keys: String,
+}


### PR DESCRIPTION
Part of #71
Also related to #71

This PR moves the token decryption service from boxer-validator-nginx project


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.