### PR TITLE
Move the validation service from `boxer-validator-nginx`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,8 +468,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_norway",
+ "strum",
+ "strum_macros",
  "test-context",
  "tokio",
+ "url",
  "uuid",
 ]
 
@@ -3393,6 +3396,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,9 @@ env_filter = "0.1.3"
 josekit = "0.10.3"
 md5 = "0.8.0"
 jsonwebtoken = "10.3.0"
+strum_macros = "0.27"
+strum = "0.28.0"
+url = "2.5.4"
 
 # Open Telemetry dependencies
 opentelemetry = "0.30.0"

--- a/src/services.rs
+++ b/src/services.rs
@@ -4,3 +4,4 @@ pub mod base;
 pub mod observability;
 pub mod service_provider;
 pub mod token_decryption_service;
+pub mod validation_service;

--- a/src/services/validation_service.rs
+++ b/src/services/validation_service.rs
@@ -1,0 +1,17 @@
+pub mod cedar_validation_service;
+mod http_method;
+mod path_segment;
+mod request_context;
+mod request_segment;
+mod required_claims;
+mod schema_provider;
+
+use crate::services::validation_service::request_context::RequestContext;
+use crate::services::validation_service::required_claims::RequiredClaims;
+use async_trait::async_trait;
+
+/// Validates the Claims and RequestContext against the policies and schemas defined in the system.
+#[async_trait]
+pub trait ValidationService<Claims: RequiredClaims>: Send + Sync {
+    async fn validate(&self, boxer_claims: Claims, request_context: RequestContext) -> Result<(), anyhow::Error>;
+}

--- a/src/services/validation_service/cedar_validation_service.rs
+++ b/src/services/validation_service/cedar_validation_service.rs
@@ -1,0 +1,134 @@
+use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
+use crate::services::audit::AuditService;
+use crate::services::base::upsert_repository::ReadOnlyRepository;
+use crate::services::observability::open_telemetry::metrics::authorization_metric::AuthorizationMetric;
+use crate::services::observability::open_telemetry::metrics::metric_recorders::token_accepted::TokenAccepted;
+use crate::services::observability::open_telemetry::metrics::metric_recorders::token_rejected::TokenRejected;
+use crate::services::observability::open_telemetry::metrics::provider::MetricsProvider;
+use crate::services::observability::open_telemetry::tracing::start_trace;
+use crate::services::service_provider::ServiceProvider;
+use crate::services::validation_service::path_segment::PathSegment;
+use crate::services::validation_service::request_context::RequestContext;
+use crate::services::validation_service::request_segment::RequestSegment;
+use crate::services::validation_service::required_claims::RequiredClaims;
+use crate::services::validation_service::schema_provider::SchemaProvider;
+use crate::services::validation_service::ValidationService;
+use async_trait::async_trait;
+use cedar_policy::{Authorizer, Context, Entities, EntityUid, PolicySet, Request};
+use log::{debug, info};
+use opentelemetry::context::FutureExt;
+use std::sync::Arc;
+
+/// Abstracts the ReadOnlyRepository that contains EntityUid objects.
+type EntityUidRepository<Key> = dyn ReadOnlyRepository<Key, EntityUid, ReadError = anyhow::Error>;
+
+/// The repository that contains Action UIDs
+pub type ActionRepository = EntityUidRepository<(String, Vec<RequestSegment>)>;
+
+/// The repository that contains Resource UIDs
+pub type ResourceRepository = EntityUidRepository<(String, Vec<PathSegment>)>;
+
+/// Abstracts the repository that contains PolicySet objects.
+pub type PolicyRepository = dyn ReadOnlyRepository<String, PolicySet, ReadError = anyhow::Error>;
+
+pub struct CedarValidationService {
+    authorizer: Authorizer,
+    schema_provider: Arc<dyn SchemaProvider>,
+    action_repository: Arc<ActionRepository>,
+    resource_repository: Arc<ResourceRepository>,
+    policy_repository: Arc<PolicyRepository>,
+    audit: Arc<dyn AuditService>,
+    metrics_provider: MetricsProvider,
+}
+
+impl CedarValidationService {
+    /// Creates the new instance of the CedarValidationService
+    pub fn new(
+        schema_provider: Arc<dyn SchemaProvider>,
+        action_repository: Arc<ActionRepository>,
+        resource_repository: Arc<ResourceRepository>,
+        policy_repository: Arc<PolicyRepository>,
+        audit: Arc<dyn AuditService>,
+        metrics_provider: MetricsProvider,
+    ) -> Self {
+        CedarValidationService {
+            authorizer: Authorizer::new(),
+            schema_provider,
+            action_repository,
+            resource_repository,
+            policy_repository,
+            audit,
+            metrics_provider,
+        }
+    }
+}
+
+#[async_trait]
+impl<Claims> ValidationService<Claims> for CedarValidationService
+where
+    Claims: RequiredClaims + Send + Sync + 'static,
+{
+    async fn validate(&self, claims: Claims, request_context: RequestContext) -> Result<(), anyhow::Error> {
+        let ctx = start_trace("request_validation", None);
+        let schema = self
+            .schema_provider
+            .get_schema(claims.get_validator_schema_id().clone())
+            .with_context(ctx.clone())
+            .await?;
+        debug!("Cedar validation schemas: {:?}", schema);
+
+        let action = self
+            .action_repository
+            .get((
+                claims.get_validator_schema_id().clone(),
+                request_context.clone().try_into()?,
+            ))
+            .with_context(ctx.clone())
+            .await?;
+
+        let resource = self
+            .resource_repository
+            .get((
+                claims.get_validator_schema_id().clone(),
+                request_context.clone().try_into()?,
+            ))
+            .with_context(ctx.clone())
+            .await?;
+
+        let policy_set = self
+            .policy_repository
+            .get(claims.get_validator_schema_id().clone())
+            .with_context(ctx.clone())
+            .await?;
+
+        let actor: EntityUid = claims.get_principal().uid();
+
+        let entities = Entities::empty().add_entities(vec![claims.get_principal().clone()], None)?;
+        let request = Request::new(actor.clone(), action.clone(), resource.clone(), Context::empty(), None)?;
+        let answer = self.authorizer.is_authorized(&request, &policy_set, &entities);
+
+        info!(
+            "validation {:?} for actor {:?} action {:?} on resource {:?}",
+            answer,
+            actor.to_string(),
+            action.to_string(),
+            resource.to_string()
+        );
+
+        self.audit
+            .record_authorization(AuthorizationAuditEvent::new(&actor, &action, &resource, &answer))?;
+
+        match answer.decision() {
+            cedar_policy::Decision::Allow => {
+                let metric: TokenAccepted = self.metrics_provider.get();
+                metric.increment(actor, action, resource);
+                Ok(())
+            }
+            cedar_policy::Decision::Deny => {
+                let metric: TokenRejected = self.metrics_provider.get();
+                metric.increment(actor, action, resource);
+                anyhow::bail!("Access denied")
+            }
+        }
+    }
+}

--- a/src/services/validation_service/cedar_validation_service.rs
+++ b/src/services/validation_service/cedar_validation_service.rs
@@ -1,5 +1,5 @@
-use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
 use crate::services::audit::AuditService;
+use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
 use crate::services::base::upsert_repository::ReadOnlyRepository;
 use crate::services::observability::open_telemetry::metrics::authorization_metric::AuthorizationMetric;
 use crate::services::observability::open_telemetry::metrics::metric_recorders::token_accepted::TokenAccepted;
@@ -7,12 +7,12 @@ use crate::services::observability::open_telemetry::metrics::metric_recorders::t
 use crate::services::observability::open_telemetry::metrics::provider::MetricsProvider;
 use crate::services::observability::open_telemetry::tracing::start_trace;
 use crate::services::service_provider::ServiceProvider;
+use crate::services::validation_service::ValidationService;
 use crate::services::validation_service::path_segment::PathSegment;
 use crate::services::validation_service::request_context::RequestContext;
 use crate::services::validation_service::request_segment::RequestSegment;
 use crate::services::validation_service::required_claims::RequiredClaims;
 use crate::services::validation_service::schema_provider::SchemaProvider;
-use crate::services::validation_service::ValidationService;
 use async_trait::async_trait;
 use cedar_policy::{Authorizer, Context, Entities, EntityUid, PolicySet, Request};
 use log::{debug, info};

--- a/src/services/validation_service/http_method.rs
+++ b/src/services/validation_service/http_method.rs
@@ -1,0 +1,24 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumString};
+
+#[derive(
+    Debug, Ord, PartialOrd, Eq, Clone, EnumString, Serialize, Deserialize, JsonSchema, Display, Hash, PartialEq,
+)]
+#[strum(serialize_all = "UPPERCASE")]
+pub enum HTTPMethod {
+    #[strum(ascii_case_insensitive)]
+    Get,
+    #[strum(ascii_case_insensitive)]
+    Post,
+    #[strum(ascii_case_insensitive)]
+    Put,
+    #[strum(ascii_case_insensitive)]
+    Delete,
+    #[strum(ascii_case_insensitive)]
+    Patch,
+    #[strum(ascii_case_insensitive)]
+    Head,
+    #[strum(ascii_case_insensitive)]
+    Options,
+}

--- a/src/services/validation_service/path_segment.rs
+++ b/src/services/validation_service/path_segment.rs
@@ -1,0 +1,25 @@
+use crate::services::validation_service::request_context::RequestContext;
+use strum_macros::Display;
+use url::Url;
+
+#[derive(Debug, Clone, Display, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub enum PathSegment {
+    Static(String),
+    Parameter,
+}
+
+impl TryFrom<RequestContext> for Vec<PathSegment> {
+    type Error = anyhow::Error;
+
+    fn try_from(context: RequestContext) -> Result<Self, Self::Error> {
+        let uri = Url::parse(context.original_url.as_str())?;
+        let mut segments = vec![];
+        for part in uri.path().split('/') {
+            if part.is_empty() {
+                continue; // Skip empty segments
+            }
+            segments.push(PathSegment::Static(part.to_string()));
+        }
+        Ok(segments)
+    }
+}

--- a/src/services/validation_service/request_context.rs
+++ b/src/services/validation_service/request_context.rs
@@ -1,0 +1,29 @@
+use actix_web::http::Uri;
+use cedar_policy::{EntityId, EntityTypeName, EntityUid};
+use std::str::FromStr;
+
+/// Contains the request context for validation.
+#[derive(Debug, Clone)]
+pub struct RequestContext {
+    pub original_url: String,
+    pub original_method: String,
+}
+
+impl RequestContext {
+    /// Creates a new `RequestContext` with the given original URL and method.
+    pub fn new(original_url: String, original_method: String) -> RequestContext {
+        RequestContext {
+            original_url,
+            original_method,
+        }
+    }
+
+    /// Converts this request into a Cedar `EntityUid` representing the HTTP resource.
+    pub fn to_resource(&self) -> anyhow::Result<EntityUid> {
+        let tp = EntityTypeName::from_str("Http")?;
+        let uri = self.original_url.parse::<Uri>()?;
+        let name = uri.host().unwrap().to_string() + uri.path();
+        let n = EntityId::from_str(&name)?;
+        Ok(EntityUid::from_type_name_and_id(tp, n))
+    }
+}

--- a/src/services/validation_service/request_segment.rs
+++ b/src/services/validation_service/request_segment.rs
@@ -1,0 +1,50 @@
+use crate::services::validation_service::http_method::HTTPMethod;
+use crate::services::validation_service::path_segment::PathSegment;
+use crate::services::validation_service::request_context::RequestContext;
+use anyhow::anyhow;
+use strum_macros::Display;
+use url::Url;
+
+/// Represents a segment of a HTTP request.
+/// Each segment can be a verb (HTTP method), hostname, static string, or a parameter.
+/// e.g., in the request `GET https://example.com/api/resource/{id}/property`, the segments would be:
+///   - Verb: `GET`
+///   - Hostname: `example.com`
+///   - Static: `api`
+///   - Static: `resource`
+///   - Parameter: `{id}`
+/// Does not include the query string or fragment.
+#[derive(Debug, Clone, Display, Hash, Ord, PartialOrd, Eq, PartialEq)]
+pub enum RequestSegment {
+    Hostname(String),
+    Verb(HTTPMethod),
+    Path(PathSegment),
+}
+
+impl TryFrom<RequestContext> for Vec<RequestSegment> {
+    type Error = anyhow::Error;
+
+    /// Attempts to convert a `RequestContext` into a vector of `RequestSegment`s.
+    /// This involves parsing the original URL and method from the context.
+    fn try_from(context: RequestContext) -> Result<Self, Self::Error> {
+        let verb = context.original_method.clone();
+        let uri = Url::parse(context.original_url.as_str())?;
+        let hostname = uri
+            .host_str()
+            .ok_or_else(|| anyhow!("Invalid URL: missing host"))?
+            .to_string();
+        let mut segments = vec![];
+        let method = verb.parse::<HTTPMethod>()?;
+        segments.push(RequestSegment::Hostname(hostname));
+        segments.push(RequestSegment::Verb(method));
+
+        for part in uri.path().split('/') {
+            if part.is_empty() {
+                continue; // Skip empty segments
+            }
+            segments.push(RequestSegment::Path(PathSegment::Static(part.to_string())));
+        }
+
+        Ok(segments)
+    }
+}

--- a/src/services/validation_service/required_claims.rs
+++ b/src/services/validation_service/required_claims.rs
@@ -1,0 +1,10 @@
+use cedar_policy::Entity;
+
+/// Represents a container of JWT claims required for the token validation.
+pub trait RequiredClaims {
+    /// Returns the validator schema id from the claims.
+    fn get_validator_schema_id(&self) -> String;
+
+    /// Returns the parsed principal from the claims.
+    fn get_principal(&self) -> Entity;
+}

--- a/src/services/validation_service/schema_provider.rs
+++ b/src/services/validation_service/schema_provider.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use cedar_policy::Schema;
+
+/// Reads the schema from the external storage.
+#[async_trait]
+pub trait SchemaProvider: Send + Sync {
+    /// Returns the schema with the specified name.
+    async fn get_schema(&self, name: String) -> Result<Schema>;
+}


### PR DESCRIPTION
Part of #71
Also related to #71

Move the CedarValidationService from `boxer-validator-nginx` project


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.