### PR TITLE
Move token service from boxer-issuer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ target/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+
+# Integrationtest state files and generated directories
+/integration-tests/helm/setup/charts/

--- a/src/services.rs
+++ b/src/services.rs
@@ -4,4 +4,5 @@ pub mod base;
 pub mod observability;
 pub mod service_provider;
 pub mod token_decryption_service;
+pub mod token_service;
 pub mod validation_service;

--- a/src/services/token_service.rs
+++ b/src/services/token_service.rs
@@ -1,0 +1,15 @@
+pub mod encrypted_token_service;
+mod external_identity;
+mod principal;
+mod principal_service;
+
+use crate::services::token_service::external_identity::ExternalIdentity;
+use async_trait::async_trait;
+
+#[async_trait]
+/// The TokenProvider crate abstracts the service that used to issue an internal token based on the
+/// provided external and identity information.
+pub trait TokenProvider: Send + Sync + 'static {
+    /// Issues an internal token.
+    async fn issue_token(&self, external_token: ExternalIdentity) -> Result<String, anyhow::Error>;
+}

--- a/src/services/token_service/encrypted_token_service.rs
+++ b/src/services/token_service/encrypted_token_service.rs
@@ -1,0 +1,90 @@
+use crate::contracts::internal_token::v1::token::InternalToken;
+use crate::services::observability::open_telemetry::metrics::metric_recorders::token_issued::{
+    TokenIssued, TokenIssuedMetric,
+};
+use crate::services::observability::open_telemetry::metrics::metric_recorders::token_lifetime::{
+    TokenLifetime, TokenLifetimeMetric,
+};
+use crate::services::observability::open_telemetry::metrics::provider::MetricsProvider;
+use crate::services::service_provider::ServiceProvider;
+use crate::services::token_service::TokenProvider;
+use crate::services::token_service::external_identity::ExternalIdentity;
+use crate::services::token_service::principal_service::PrincipalService;
+use async_trait::async_trait;
+use josekit::jwe::{Dir, JweHeader};
+use josekit::jwt;
+use josekit::jwt::JwtPayload;
+use std::sync::Arc;
+use std::time::Duration;
+
+pub struct EncryptedTokenService {
+    principal_service: Arc<dyn PrincipalService>,
+    encrypt_secret: Arc<Vec<u8>>,
+    audience: String,
+    key_id: String,
+    issuer: String,
+    content_encryption: String,
+    token_duration: Duration,
+    metrics_provider: MetricsProvider,
+}
+
+#[async_trait]
+impl TokenProvider for EncryptedTokenService {
+    async fn issue_token(&self, identity: ExternalIdentity) -> Result<String, anyhow::Error> {
+        let principal = self.principal_service.get_principal(identity.clone()).await?;
+        let schema_name = principal.get_schema_id().clone();
+        let schemas = self.principal_service.get_schemas(schema_name.clone()).await?;
+        let validator_schema_id = self.principal_service.get_validator_schema(identity.clone()).await?;
+        let payload: JwtPayload = InternalToken::new(
+            principal.get_entity().clone(),
+            schemas,
+            identity.user_id.clone(),
+            identity.identity_provider.clone(),
+            schema_name,
+            self.token_duration.clone(),
+            validator_schema_id,
+        )
+        .try_into()?;
+
+        let mut header = JweHeader::new();
+        header.set_token_type("JWT");
+        header.set_audience(vec![self.audience.as_str()]);
+        header.set_issuer(self.issuer.clone());
+        header.set_content_encryption(&self.content_encryption);
+        header.set_key_id(&self.key_id);
+
+        let encrypter = Dir.encrypter_from_bytes(&*self.encrypt_secret)?;
+        let token = jwt::encode_with_encrypter(&payload, &header, &encrypter).map_err(|e| anyhow::anyhow!(e))?;
+
+        let ti: TokenIssued = self.metrics_provider.get();
+        ti.increment(identity.identity_provider.clone(), identity.user_id.clone());
+
+        let tl: TokenLifetime = self.metrics_provider.get();
+        tl.increment(identity.identity_provider, identity.user_id, self.token_duration);
+
+        Ok(token)
+    }
+}
+
+impl EncryptedTokenService {
+    pub fn new(
+        principal_service: Arc<dyn PrincipalService>,
+        encrypt_secret: Arc<Vec<u8>>,
+        key_id: String,
+        audience: String,
+        issuer: String,
+        content_encryption: String,
+        metrics_provider: MetricsProvider,
+    ) -> Self {
+        EncryptedTokenService {
+            principal_service,
+            encrypt_secret,
+            key_id,
+            audience,
+            issuer,
+            content_encryption,
+            token_duration: Duration::from_secs(3600),
+            metrics_provider,
+        }
+    }
+}

--- a/src/services/token_service/external_identity.rs
+++ b/src/services/token_service/external_identity.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+/// Struct that represents an external identity
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+pub struct ExternalIdentity {
+    /// The user ID extracted from the external identity provider
+    pub user_id: String,
+
+    /// The name of the external identity provider
+    pub identity_provider: String,
+}
+
+impl ExternalIdentity {
+    /// Creates a new instance of an external identity
+    pub fn new(identity_provider: String, user_id: String) -> Self {
+        ExternalIdentity {
+            user_id: user_id.to_lowercase(),
+            identity_provider: identity_provider.to_lowercase(),
+        }
+    }
+}
+
+impl From<(String, String)> for ExternalIdentity {
+    fn from(value: (String, String)) -> Self {
+        ExternalIdentity::new(value.0, value.1)
+    }
+}

--- a/src/services/token_service/principal.rs
+++ b/src/services/token_service/principal.rs
@@ -1,0 +1,54 @@
+use cedar_policy::Entity;
+use serde::ser::SerializeStruct;
+use serde::{Deserialize, Serialize};
+
+/// `[Principal]` represents an internal principal in the system.
+/// Principal consists from a Cedar entity and a schema id.
+#[derive(Debug, Clone)]
+pub struct Principal {
+    entity: Entity,
+    schema_id: String,
+}
+
+impl Principal {
+    pub fn new(entity: Entity, schema_id: String) -> Self {
+        Self { entity, schema_id }
+    }
+
+    pub fn get_entity(&self) -> &Entity {
+        &self.entity
+    }
+
+    pub fn get_schema_id(&self) -> &String {
+        &self.schema_id
+    }
+}
+
+impl Serialize for Principal {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Principal", 2)?;
+        state.serialize_field("entity", &self.entity.to_string())?;
+        state.serialize_field("schema_id", &self.schema_id)?;
+        state.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for Principal {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct PrincipalData {
+            entity: String,
+            schema_id: String,
+        }
+
+        let data = PrincipalData::deserialize(deserializer)?;
+        let entity = Entity::from_json_str(&data.entity, None).map_err(serde::de::Error::custom)?;
+        Ok(Self::new(entity, data.schema_id))
+    }
+}

--- a/src/services/token_service/principal_service.rs
+++ b/src/services/token_service/principal_service.rs
@@ -1,0 +1,21 @@
+use crate::services::token_service::external_identity::ExternalIdentity;
+use crate::services::token_service::principal::Principal;
+use anyhow::Result;
+use async_trait::async_trait;
+use cedar_policy::SchemaFragment;
+
+/// Manages an information about the principal in the system.
+/// It provides methods to retrieve principal information, validator schemas, and schema
+/// fragments based on external identity.
+#[async_trait]
+pub trait PrincipalService: Send + Sync + 'static {
+    /// Retrieves an internal principal information.
+    async fn get_principal(&self, external_identity: ExternalIdentity) -> Result<Principal>;
+
+    /// Returns a validator schema associated to the principal.
+    async fn get_validator_schema(&self, external_identity: ExternalIdentity) -> Result<String>;
+
+    /// Return schema fragments that should be used to validate the principal on the
+    /// validator side.
+    async fn get_schemas(&self, schema_id: String) -> Result<SchemaFragment, anyhow::Error>;
+}


### PR DESCRIPTION
Part of #71

To implement an end-to-end of an audit pipeline in boxer-core we need to move the `TokenService` from boxer-issuer to boxer-core.


## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.