### PR TITLE
Implement ability to upgrade claims version

### DIFF
--- a/src/contracts/internal_token/v1/boxer_claims.rs
+++ b/src/contracts/internal_token/v1/boxer_claims.rs
@@ -3,6 +3,9 @@ mod tests;
 
 use crate::contracts::dynamic_claims_collection::DynamicClaims;
 use crate::contracts::internal_token::v1::{PRINCIPAL_KEY, SCHEMA_ID_KEY, SCHEMA_KEY, VALIDATOR_SCHEMA_ID_KEY};
+use crate::contracts::internal_token::v2::boxer_claims::BoxerClaims as V2BoxerClaims;
+use crate::http::middleware::audit::internal_request::upgrade_version::UpgradeVersion;
+use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::validation_service::required_claims::RequiredClaims;
 use cedar_policy::{Entity, SchemaFragment};
 
@@ -60,5 +63,21 @@ impl RequiredClaims for BoxerClaims {
 
     fn get_schema(&self) -> SchemaFragment {
         self.schema.clone()
+    }
+}
+
+impl UpgradeVersion for BoxerClaims {
+    type Result = V2BoxerClaims;
+
+    type Context = ChainedAuditEvent;
+
+    fn upgrade_version(self, audit_event: Self::Context) -> V2BoxerClaims {
+        V2BoxerClaims {
+            schema: self.schema,
+            schema_id: self.schema_id,
+            validator_schema_id: self.validator_schema_id,
+            principal: self.principal,
+            audit_event,
+        }
     }
 }

--- a/src/http/middleware/audit/audited_error.rs
+++ b/src/http/middleware/audit/audited_error.rs
@@ -69,6 +69,7 @@ impl AuditedError {
         }
     }
 }
+
 impl ExternalTokenError for AuditedError {
     /// Creates an `AuditedError` in case when the external token is not present.
     ///

--- a/src/http/middleware/audit/internal_request.rs
+++ b/src/http/middleware/audit/internal_request.rs
@@ -14,9 +14,9 @@ use crate::http::middleware::token_decryptor_middleware::request_with_token::Req
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
+use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
-use actix_web::HttpMessage;
 use anyhow::bail;
 use upgrade_version::UpgradeVersion;
 

--- a/src/http/middleware/audit/internal_request.rs
+++ b/src/http/middleware/audit/internal_request.rs
@@ -1,17 +1,24 @@
 #[cfg(test)]
 mod tests;
+pub mod upgrade_version;
 
 use super::begin_audit_chain::try_create_audit_context::TryCreateAuditContext;
+use crate::contracts::dynamic_claims_collection::{DynamicClaims, DynamicClaimsCollection};
 use crate::contracts::internal_token::encrypted_token::EncryptedToken;
+use crate::contracts::internal_token::v1::boxer_claims::ToBoxerClaims as V1ToBoxerClaims;
+use crate::contracts::internal_token::v2::boxer_claims::ToBoxerClaims as V2ToBoxerClaims;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
 use crate::http::middleware::extract_external_token::token_with_id::TokenWithId;
 use crate::http::middleware::request_with_token_id::RequestWithTokenId;
+use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::chained::chained_audit_event::ChainedAuditEvent;
 use crate::services::audit::chained::token_audit_event::TokenAuditEvent;
-use actix_web::HttpMessage;
 use actix_web::dev::ServiceRequest;
 use actix_web::error::ErrorInternalServerError;
+use actix_web::HttpMessage;
+use anyhow::bail;
+use upgrade_version::UpgradeVersion;
 
 /// [`InternalRequest`] is a wrapper around `ServiceRequest` that indicates the request has been
 /// processed by the `begin_audit_chain` middleware and has an audit context initialized.
@@ -19,6 +26,19 @@ use actix_web::error::ErrorInternalServerError;
 /// multiple initializations of the audit context for the same request.
 #[derive(Debug)]
 pub struct InternalRequest(ServiceRequest);
+
+impl InternalRequest {
+    fn update_audit_event<F>(&mut self, callback: F) -> Result<(), anyhow::Error>
+    where
+        F: FnOnce(&mut AuditEvent) -> Result<(), anyhow::Error>,
+    {
+        let mut extensions = self.0.extensions_mut();
+        let audit_event = extensions
+            .get_mut()
+            .ok_or_else(|| anyhow::anyhow!("Audit event not found in request extensions"))?;
+        callback(audit_event)
+    }
+}
 
 /// Implementing `Into<ServiceRequest>` allows us to easily convert an `AuditedRequest` back into
 /// a `ServiceRequest` when passing it to the next middleware or handler in the chain.
@@ -130,5 +150,62 @@ impl RequestWithTokenId for InternalRequest {
 
         // Return the updated value
         self.0
+    }
+}
+
+impl RequestWithToken for InternalRequest {
+    fn token(&self) -> EncryptedToken {
+        self.0
+            .extensions()
+            .get::<EncryptedToken>()
+            .cloned()
+            .expect("Encrypted token not exists in request extensions")
+    }
+
+    fn set_claims(mut self, claims: DynamicClaimsCollection) -> Result<ServiceRequest, anyhow::Error> {
+        // If we have the token version 2, we should extract the audit event from the token and
+
+        let version = claims.get_version()?;
+        let boxer_claims = match version.as_str() {
+            "v1" => {
+                let claims_v1 = V1ToBoxerClaims::to_boxer_claims(&claims)?;
+                let event = self.audit_event();
+                match event {
+                    AuditEvent::Intermediate(e) => claims_v1.upgrade_version(e),
+                    _ => anyhow::bail!("Unexpected audit event type when upgrading claims: {:?}", event),
+                }
+            }
+            "v2" => V2ToBoxerClaims::to_boxer_claims(&claims)?,
+            _ => return Err(anyhow::anyhow!("Unexpected claims version: {:?}", version)),
+        };
+
+        self.update_audit_event(|audit_event| {
+            match audit_event {
+                AuditEvent::Intermediate(ChainedAuditEvent {
+                    external_token: token, ..
+                }) => {
+                    *token = boxer_claims.audit_event.external_token.clone();
+                }
+                _ => anyhow::bail!("Unexpected audit event type when setting claims: {:?}", audit_event),
+            }
+            *audit_event = AuditEvent::Intermediate(boxer_claims.audit_event.clone());
+            Ok(())
+        })?;
+
+        self.0.extensions_mut().insert(boxer_claims);
+        Ok(self.0)
+    }
+
+    fn try_from_request(request: ServiceRequest) -> Result<Self, anyhow::Error> {
+        if !request.extensions().contains::<EncryptedToken>() {
+            bail!("Missing required encrypted token extension");
+        };
+
+        if !request.extensions().contains::<AuditEvent>() {
+            panic!("Request does not contain AuditEvent in request extensions");
+        }
+
+        let internal_request = InternalRequest(request);
+        Ok(internal_request)
     }
 }

--- a/src/http/middleware/audit/internal_request/upgrade_version.rs
+++ b/src/http/middleware/audit/internal_request/upgrade_version.rs
@@ -1,0 +1,14 @@
+/// The trait that defines the behavior for upgrading the version of a BoxerClaims instance.
+/// The implementation defines the target version of the BoxerClaims and the logic for upgrading to
+/// that version.
+pub trait UpgradeVersion {
+    /// The new BoxerClaims version to upgrade the claims
+    type Result;
+
+    /// The additional context for the version upgrade.
+    type Context;
+
+    /// Upgrades the version. If callee needs an additional context, this method should be
+    /// implemented for a tuple that contains the source type and the additional context.
+    fn upgrade_version(self, context: Self::Context) -> Self::Result;
+}

--- a/src/http/middleware/token_decryptor_middleware.rs
+++ b/src/http/middleware/token_decryptor_middleware.rs
@@ -5,7 +5,7 @@ pub mod token_decryptor_middleware_factory;
 use crate::http::middleware::audit::audited_error::AuditedError;
 use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
 use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
-use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
+use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
 use actix_web::error::ErrorBadRequest;
 use futures_util::future::LocalBoxFuture;
 use std::marker::PhantomData;
@@ -21,14 +21,14 @@ pub struct TokenDecryptorMiddleware<Next, D, R> {
 
 impl<Next, Body, D, R> Service<ServiceRequest> for TokenDecryptorMiddleware<Next, D, R>
 where
-    Next: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = AuditedError> + 'static,
+    Next: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = actix_web::Error> + 'static,
     Next::Future: 'static,
     Body: 'static,
     D: Decryptor + 'static,
     R: RequestWithToken + 'static,
 {
     type Response = ServiceResponse<Body>;
-    type Error = AuditedError;
+    type Error = actix_web::Error;
     type Future = LocalBoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     forward_ready!(next);
@@ -38,13 +38,13 @@ where
         let decryptor = self.decryptor.clone();
         let next = self.next.clone();
         let future = async move {
-            let mut request_with_token = R::try_from(req)?;
-            let encrypted_token = request_with_token.token();
+            let req = R::try_from_request(req).map_err(ErrorBadRequest)?;
+            let encrypted_token = req.token();
             let claims = decryptor
                 .decrypt(encrypted_token)
                 .map_err(ErrorBadRequest)
-                .map_err(|e| AuditedError::new(request_with_token.audit_event(), e))?;
-            next.call(request_with_token.set_claims(claims)).await
+                .map_err(|e| AuditedError::new(req.audit_event(), e))?;
+            next.call(req.set_claims(claims).map_err(ErrorBadRequest)?).await
         };
         Box::pin(future)
     }

--- a/src/http/middleware/token_decryptor_middleware.rs
+++ b/src/http/middleware/token_decryptor_middleware.rs
@@ -5,7 +5,7 @@ pub mod token_decryptor_middleware_factory;
 use crate::http::middleware::audit::audited_error::AuditedError;
 use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
 use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
-use actix_web::dev::{forward_ready, Service, ServiceRequest, ServiceResponse};
+use actix_web::dev::{Service, ServiceRequest, ServiceResponse, forward_ready};
 use actix_web::error::ErrorBadRequest;
 use futures_util::future::LocalBoxFuture;
 use std::marker::PhantomData;

--- a/src/http/middleware/token_decryptor_middleware/request_with_token.rs
+++ b/src/http/middleware/token_decryptor_middleware/request_with_token.rs
@@ -1,14 +1,18 @@
 use crate::contracts::dynamic_claims_collection::DynamicClaimsCollection;
 use crate::contracts::internal_token::encrypted_token::EncryptedToken;
 use crate::http::middleware::audit::audit_recorder::audit_event_source::AuditEventSource;
-use crate::http::middleware::audit::audited_error::AuditedError;
 use actix_web::dev::ServiceRequest;
 
 /// Abstraction over request types that carry an encrypted internal token.
-pub trait RequestWithToken: TryFrom<ServiceRequest, Error = AuditedError> + AuditEventSource {
+pub trait RequestWithToken: AuditEventSource {
     /// Returns the encrypted token extracted from the request.
     fn token(&self) -> EncryptedToken;
 
     /// Stores decrypted claims in the request context and returns the updated request.
-    fn set_claims(&mut self, claims: DynamicClaimsCollection) -> ServiceRequest;
+    fn set_claims(self, claims: DynamicClaimsCollection) -> Result<ServiceRequest, anyhow::Error>;
+
+    /// Extracts encrypted token from ServiceRequest.
+    fn try_from_request(request: ServiceRequest) -> Result<Self, anyhow::Error>
+    where
+        Self: Sized;
 }

--- a/src/http/middleware/token_decryptor_middleware/token_decryptor_middleware_factory.rs
+++ b/src/http/middleware/token_decryptor_middleware/token_decryptor_middleware_factory.rs
@@ -1,9 +1,8 @@
-use crate::http::middleware::audit::audited_error::AuditedError;
-use crate::http::middleware::token_decryptor_middleware::TokenDecryptorMiddleware;
 use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
 use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
+use crate::http::middleware::token_decryptor_middleware::TokenDecryptorMiddleware;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
-use futures_util::future::{Ready, ready};
+use futures_util::future::{ready, Ready};
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -26,14 +25,14 @@ impl<D, R> TokenDecryptorMiddlewareFactory<D, R> {
 
 impl<Next, Body, D, R> Transform<Next, ServiceRequest> for TokenDecryptorMiddlewareFactory<D, R>
 where
-    Next: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = AuditedError> + 'static,
+    Next: Service<ServiceRequest, Response = ServiceResponse<Body>, Error = actix_web::Error> + 'static,
     Next::Future: 'static,
     Body: 'static,
     R: RequestWithToken + 'static,
     D: Decryptor + 'static,
 {
     type Response = ServiceResponse<Body>;
-    type Error = AuditedError;
+    type Error = actix_web::Error;
     type Transform = TokenDecryptorMiddleware<Next, D, R>;
     type InitError = ();
     type Future = Ready<Result<Self::Transform, Self::InitError>>;

--- a/src/http/middleware/token_decryptor_middleware/token_decryptor_middleware_factory.rs
+++ b/src/http/middleware/token_decryptor_middleware/token_decryptor_middleware_factory.rs
@@ -1,8 +1,8 @@
+use crate::http::middleware::token_decryptor_middleware::TokenDecryptorMiddleware;
 use crate::http::middleware::token_decryptor_middleware::decryptor::Decryptor;
 use crate::http::middleware::token_decryptor_middleware::request_with_token::RequestWithToken;
-use crate::http::middleware::token_decryptor_middleware::TokenDecryptorMiddleware;
 use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
-use futures_util::future::{ready, Ready};
+use futures_util::future::{Ready, ready};
 use std::marker::PhantomData;
 use std::rc::Rc;
 use std::sync::Arc;


### PR DESCRIPTION
Part of #71
Also related to #70

Implements ability to convert claims version 1 (currently issued by boxer-issuer) to claims version 2 (will be implemented in the next PRs).

Token version 2 will contain the ChainedAuditEvent in the payload which allows to track the authz events and correlate them with the external token.

 Additionally, the error types are temporary simplified.

Unit tests will be added in the next PRs.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.