### PR TITLE
Make the decision field optional

### DIFF
--- a/src/services/audit/chained/audit_event/audit_event_properties.rs
+++ b/src/services/audit/chained/audit_event/audit_event_properties.rs
@@ -11,17 +11,32 @@ pub struct AuditEventProperties {
 
     pub reason: Reason,
 
-    pub decision: Decision,
-
     pub external_token_id: String,
 
     pub internal_token_id: String,
+
+    decision: Option<Decision>,
+}
+
+impl AuditEventProperties {
+    pub fn new(decision: Decision) -> Self {
+        Self {
+            decision: Some(decision),
+            ..Default::default()
+        }
+    }
+
+    pub fn decision(&self) -> String {
+        self.decision
+            .map(|decision| format!("{:?}", decision))
+            .unwrap_or("".to_string())
+    }
 }
 
 impl Default for AuditEventProperties {
     fn default() -> Self {
         Self {
-            is_final: Default::default(),
+            is_final: false,
             action: Default::default(),
             actor: Default::default(),
             resource: Default::default(),
@@ -29,7 +44,7 @@ impl Default for AuditEventProperties {
                 policies: Default::default(),
                 errors: Default::default(),
             },
-            decision: Decision::Deny,
+            decision: None,
             external_token_id: Default::default(),
             internal_token_id: Default::default(),
         }

--- a/src/services/audit/chained/audit_event/final_audit_event.rs
+++ b/src/services/audit/chained/audit_event/final_audit_event.rs
@@ -11,32 +11,20 @@ pub struct FinalAuditEvent {
 }
 
 impl FinalAuditEvent {
-    pub fn get_properties(&self) -> AuditEventProperties {
-        let mut properties = AuditEventProperties {
-            is_final: true,
-            decision: self.policy_evaluation_result.decision.clone(),
-            ..Default::default()
-        };
+    pub fn get_properties(self) -> AuditEventProperties {
+        let mut properties = AuditEventProperties::new(self.policy_evaluation_result.decision);
 
-        properties.action = self.policy_evaluation_result.action.clone().unwrap_or_default();
-        properties.actor = self.policy_evaluation_result.actor.clone().unwrap_or_default();
-        properties.resource = self.policy_evaluation_result.resource.clone().unwrap_or_default();
-        properties.reason = self.policy_evaluation_result.reason.clone().unwrap_or_else(|| {
+        properties.action = self.policy_evaluation_result.action.unwrap_or_default();
+        properties.actor = self.policy_evaluation_result.actor.unwrap_or_default();
+        properties.resource = self.policy_evaluation_result.resource.unwrap_or_default();
+        properties.reason = self.policy_evaluation_result.reason.unwrap_or_else(|| {
             crate::services::audit::events::authorization_audit_event::Reason {
                 policies: Default::default(),
                 errors: Default::default(),
             }
         });
-        properties.external_token_id = self
-            .external_token
-            .as_ref()
-            .map(|token| token.token_id.clone())
-            .unwrap_or_default();
-        properties.internal_token_id = self
-            .internal_token
-            .as_ref()
-            .map(|token| token.token_id.clone())
-            .unwrap_or_default();
+        properties.external_token_id = self.external_token.map(|token| token.token_id).unwrap_or_default();
+        properties.internal_token_id = self.internal_token.map(|token| token.token_id).unwrap_or_default();
 
         properties
     }

--- a/src/services/audit/chained/audit_event/intermediate_audit_event.rs
+++ b/src/services/audit/chained/audit_event/intermediate_audit_event.rs
@@ -16,22 +16,11 @@ impl IntermediateAuditEvent {
 }
 
 impl IntermediateAuditEvent {
-    pub fn get_properties(&self) -> AuditEventProperties {
-        let mut properties = AuditEventProperties {
-            is_final: false,
-            ..Default::default()
-        };
+    pub fn get_properties(self) -> AuditEventProperties {
+        let mut properties = AuditEventProperties::default();
 
-        properties.external_token_id = self
-            .external_token
-            .as_ref()
-            .map(|token| token.token_id.clone())
-            .unwrap_or_default();
-        properties.internal_token_id = self
-            .internal_token
-            .as_ref()
-            .map(|token| token.token_id.clone())
-            .unwrap_or_default();
+        properties.external_token_id = self.external_token.map(|token| token.token_id).unwrap_or_default();
+        properties.internal_token_id = self.internal_token.map(|token| token.token_id).unwrap_or_default();
 
         properties
     }

--- a/src/services/audit/log_audit_service.rs
+++ b/src/services/audit/log_audit_service.rs
@@ -1,5 +1,4 @@
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
-use crate::services::audit::AuditService;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
 use crate::services::audit::events::resource_delete_audit_event::ResourceDeleteAuditEvent;
@@ -7,6 +6,7 @@ use crate::services::audit::events::resource_modification_audit_event::{
     ModificationResult, ResourceModificationAuditEvent,
 };
 use crate::services::audit::events::token_validation_event::TokenValidationEvent;
+use crate::services::audit::AuditService;
 use anyhow::Result;
 
 pub struct LogAuditService;
@@ -130,14 +130,14 @@ impl AuditWriter for LogAuditService {
             action = payload.action,
             actor = payload.actor,
             resource = payload.resource,
-            decision:serde = payload.decision,
+            decision:serde = payload.decision(),
             reason_policies:serde = payload.reason.policies,
             reason_errors:serde = payload.reason.errors,
             external_token_id = payload.external_token_id,
             internal_token_id = payload.internal_token_id;
 
             // The log message
-            "Boxer audit event recorded with decision: {:?}", payload.decision
+            "Boxer audit event recorded with decision: {:?}", payload.decision()
         );
     }
 }

--- a/src/services/audit/log_audit_service.rs
+++ b/src/services/audit/log_audit_service.rs
@@ -1,4 +1,5 @@
 use crate::http::middleware::audit::audit_recorder::audit_writer::AuditWriter;
+use crate::services::audit::AuditService;
 use crate::services::audit::chained::audit_event::AuditEvent;
 use crate::services::audit::events::authorization_audit_event::AuthorizationAuditEvent;
 use crate::services::audit::events::resource_delete_audit_event::ResourceDeleteAuditEvent;
@@ -6,7 +7,6 @@ use crate::services::audit::events::resource_modification_audit_event::{
     ModificationResult, ResourceModificationAuditEvent,
 };
 use crate::services::audit::events::token_validation_event::TokenValidationEvent;
-use crate::services::audit::AuditService;
 use anyhow::Result;
 
 pub struct LogAuditService;


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/boxer-core/issues/71

Implemented:
- This PR fixes the incorrect decision in the boxer-issuer logs.

Additional changes:
- Simplified code by eliminating the extra `.clone()` calls.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.