### PR TITLE
Return the is_final mark to the audit event

### DIFF
--- a/src/services/audit/chained/audit_event/final_audit_event.rs
+++ b/src/services/audit/chained/audit_event/final_audit_event.rs
@@ -14,6 +14,7 @@ impl FinalAuditEvent {
     pub fn get_properties(self) -> AuditEventProperties {
         let mut properties = AuditEventProperties::new(self.policy_evaluation_result.decision);
 
+        properties.is_final = true;
         properties.action = self.policy_evaluation_result.action.unwrap_or_default();
         properties.actor = self.policy_evaluation_result.actor.unwrap_or_default();
         properties.resource = self.policy_evaluation_result.resource.unwrap_or_default();


### PR DESCRIPTION
Fixes #159

## Scope

Implemented:
- Fix the mission `is_final` mark in audit logs.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.